### PR TITLE
Improved caching mechanism for icon.js

### DIFF
--- a/api/icon.js
+++ b/api/icon.js
@@ -314,6 +314,10 @@ module.exports = async (app, req, res) => {
 
             if (!outline) { 
               ic.write(`./icons/cache/${iconCode}.png`)
+              cache[iconCode] = {
+                value: buff,
+                timeoutID: setTimeout(function() {delete cache[iconCode]}, 600000)
+              }
               return res.end(buff)
             }
 

--- a/api/icon.js
+++ b/api/icon.js
@@ -99,7 +99,7 @@ module.exports = async (app, req, res) => {
       
       if (cache[iconCode]) {
         clearTimeout(cache[iconCode].timeoutID);
-        cache[iconCode].timeoutID = setTimeout(() => delete cache[iconCode], 600000);
+        cache[iconCode].timeoutID = setTimeout(function() {delete cache[iconCode]}, 600000);
         return res.end(cache[iconCode].value);
       }
 
@@ -129,7 +129,7 @@ module.exports = async (app, req, res) => {
       function recolor(img, col) {
 
         return img.scan(0, 0, img.bitmap.width, img.bitmap.height, function (x, y, idx) {
-          if (img.bitmap.data.slice(idx, idx+3).every(val => valval => val >= 20 && val <= 255)) { // If it's not "black, i.e. we want to recolor it"
+          if (img.bitmap.data.slice(idx, idx+3).every(function(val) {return val >= 20 && val <= 255})) { // If it's not "black, i.e. we want to recolor it"
             this.bitmap.data[idx] = colors[col].r / (255 / this.bitmap.data[idx]);
             this.bitmap.data[idx + 1] = colors[col].g / (255 / this.bitmap.data[idx + 1]);
             this.bitmap.data[idx + 2] = colors[col].b / (255 / this.bitmap.data[idx + 2]);
@@ -352,7 +352,7 @@ module.exports = async (app, req, res) => {
               const buffer = canvas.toBuffer();
               cache[iconCode] = {
                 value: buffer,
-                timeoutID: setTimeout(() => delete cache[iconCode], 600000)
+                timeoutID: setTimeout(function() {delete cache[iconCode]}, 600000)
               }
               return res.end(buffer, 'base64');
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const timeout = require('connect-timeout')
 let api = true;
 let gdicons = fs.readdirSync('./icons/iconkit')
 
-//clear icon cache every ten minutes
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({extended: true}));

--- a/index.js
+++ b/index.js
@@ -2,15 +2,10 @@ const express = require('express');
 const path = require('path');
 const fs = require("fs")
 const timeout = require('connect-timeout')
-const fsExtra = require("fs-extra")
-
-fsExtra.emptyDirSync('./icons/cache')
 let api = true;
 let gdicons = fs.readdirSync('./icons/iconkit')
 
 //clear icon cache every ten minutes
-setInterval(function(){ fsExtra.emptyDirSync('./icons/cache') }, 600000);
-
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({extended: true}));

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "directory-tree": "^2.2.4",
     "express": "^4.17.1",
     "fs": "0.0.1-security",
-    "fs-extra": "^8.1.0",
     "jimp": "^0.8.4",
     "path": "^0.12.7",
     "plist": "^3.0.1",


### PR DESCRIPTION
Since you didn't like my last PR, which probably had too many changes in one go, I've only made one change here. Instead of saving the cached images to the filesystem, they are stored in memory for fast access. This allows us to have per-icon autoremoval! Previously the entire cache would be cleared every 10 minutes, regardless of whether the icon was added to the cache in the last second or 9:59 ago. This change not only removes a dependency (`fs-extra`), it also saves access time and allows repeated access of a profile to reliably persist the image in cache. I also changed the `recolor` function to look nicer with `Array.every`. Hopefully this PR is a bit more reasonable for merging!

EDIT: Removed [ES6 arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) for consistency with codebase.