### PR TITLE
Improve pointercrate integration

### DIFF
--- a/api/level.js
+++ b/api/level.js
@@ -108,10 +108,9 @@ module.exports = async (app, req, res, api, analyze) => {
 
       //demon list stuff
       if (level.difficulty == "Extreme Demon") {
-        request.get('https://www.pointercrate.com/api/v1/demons/', async function(err, resp, demonList) {
+        request.get('https://www.pointercrate.com/api/v1/demons/?name=' + x.trim(), async function(err, resp, demonList) {
           let demons = JSON.parse(demonList)
-          let foundDemon = demons.find(x => x.name.trim().toLowerCase() == level.name.trim().toLowerCase())
-          if (foundDemon) level.demonList = foundDemon.position
+          if (demons && demons[0].position <= 150) level.demonList = demons[0].position
           return sendLevel()
       })
     }

--- a/api/level.js
+++ b/api/level.js
@@ -108,7 +108,7 @@ module.exports = async (app, req, res, api, analyze) => {
 
       //demon list stuff
       if (level.difficulty == "Extreme Demon") {
-        request.get('https://www.pointercrate.com/api/v1/demons/?name=' + x.trim(), async function(err, resp, demonList) {
+        request.get('https://www.pointercrate.com/api/v1/demons/?name=' + level.name.trim(), async function(err, resp, demonList) {
           let demons = JSON.parse(demonList)
           if (demons && demons[0].position <= 150) level.demonList = demons[0].position
           return sendLevel()


### PR DESCRIPTION
the pointercrate api already contains an option to filter by level name case-insensitively :package: 

also this way more than just the top 50 is shown (as `/api/v1/demons/` by default only returns the first 50 results)

the `<= 150` check is need so that legacy demons dont show up

**Disclaimer:** I do now know much javascript/nodejs and dont have a dev setup to test the changes. Proceed with caution lol