### PR TITLE
Major improvements to icon.js

### DIFF
--- a/api/icon.js
+++ b/api/icon.js
@@ -5,11 +5,40 @@ const fs = require('fs');
 const path = require('path');
 const icons = plist.parse(fs.readFileSync("./icons/GJ_GameSheet02-uhd.plist", 'utf8')).frames
 const colors = require('../misc/colors.json')
+const queryMapper = {
+  ship: {
+    form: 'ship',
+    ind: 22
+  },
+  ball: {
+    form: 'player_ball',
+    ind: 23
+  },
+  ufo: {
+    form: 'bird',
+    ind: 24
+  },
+  wave: {
+    form: 'dart',
+    ind: 25
+  },
+  robot: {
+    form: 'robot',
+    ind: 26
+  },
+  spider: {
+    form: 'spider',
+    ind: 43
+  },
+  cursed: {
+    form: 'spider',
+    ind: 43
+  }
+}
 let cache = {};
 module.exports = async (app, req, res) => {
 
   let username = req.params.text
-  let form = 'player'
 
   request.post('http://boomlings.com/database/getGJUsers20.php', {
     form: {
@@ -31,43 +60,25 @@ module.exports = async (app, req, res) => {
       }
     }, function (err2, res2, body2) {
 
-      let response2 = body2.split('#')[0].split(':');
+      let response2 = body2 == "-1" ? '' : body2.split('#')[0].split(':');
       let account = {};
       for (let i = 0; i < response2.length; i += 2) {
         account[response2[i]] = response2[i + 1]
       }
 
-      let iconID = account[21]
-      let col1 = account[10]
-      let col2 = account[11]
-      let outline = account[28]
+      let { form, ind } = queryMapper[req.query.form] || {};
+      form = form || 'player';
 
-      if (body2 == "-1") {
-        iconID = "1"
-        col1 = "1"
-        col2 = "3"
-        outline = "0"
-      }
-
-      if (req.query.form == 'ship') { form = 'ship'; iconID = account[22] }
-      if (req.query.form == 'ball') { form = 'player_ball'; iconID = account[23] }
-      if (req.query.form == 'ufo') { form = 'bird'; iconID = account[24] }
-      if (req.query.form == 'wave') { form = 'dart'; iconID = account[25] }
-      if (req.query.form == 'robot') { form = 'robot'; iconID = account[26] }
-      if (req.query.form == 'spider' || req.query.form == 'cursed') { form = 'spider'; iconID = account[43] }
-
-      if (req.query.icon) iconID = req.query.icon
-      if (req.query.col1) col1 = req.query.col1
-      if (req.query.col2) col2 = req.query.col2
-      if (req.query.glow) outline = req.query.glow
-
-      if (!iconID) iconID = 1;
+      let iconID = req.query.icon || account[ind || 21] || 1;
+      let col1 = req.query.col1 || account[10] || 1;
+      let col2 = req.query.col2 || account[11] || 3;
+      let outline = req.query.glow || account[28] || "0";
 
       if (outline == "0") outline = false;
 
-      if (iconID && iconID.toString().length == 1) iconID = "0" + iconID
+      if (iconID && iconID.toString().length == 1) iconID = "0" + iconID;
 
-      if (col1 == 15) outline = true
+      if (col1 == 15) outline = true;
 
       let robotHead = ""; let robotMode = false; let spiderMode = false; 
       if (form == "robot" || req.query.form == "cursed") { robotHead = "01_"; robotMode = true }

--- a/api/icon.js
+++ b/api/icon.js
@@ -138,7 +138,6 @@ module.exports = async (app, req, res) => {
       if (isSpecial) {
         const legs = [1,2,3].map(function(val) {return genImageName(`0${val+1}`)});
         const glows = [1,2,3].map(function(val) {return genImageName(`0${val+1}`, '2')});
-        console.log(glows, legs);
         robotOffset1 = icons[legs[0]].spriteOffset.map(minusOrigOffset).concat(icons[legs[0]].spriteSize);
         robotOffset2 = icons[legs[1]].spriteOffset.map(minusOrigOffset).concat(icons[legs[1]].spriteSize);
         robotOffset3 = icons[legs[2]].spriteOffset.map(minusOrigOffset).concat(icons[legs[2]].spriteSize);

--- a/icons/gameSheet.json
+++ b/icons/gameSheet.json
@@ -1,0 +1,35180 @@
+{
+  "bird_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      147,
+      62
+    ],
+    "spriteSourceSize": [
+      147,
+      62
+    ],
+    "textureRect": [
+      [
+        325,
+        558
+      ],
+      [
+        147,
+        62
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      139,
+      56
+    ],
+    "spriteSourceSize": [
+      139,
+      56
+    ],
+    "textureRect": [
+      [
+        1526,
+        752
+      ],
+      [
+        139,
+        56
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_01_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      123,
+      78
+    ],
+    "spriteSourceSize": [
+      123,
+      196
+    ],
+    "textureRect": [
+      [
+        642,
+        1309
+      ],
+      [
+        123,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      154,
+      74
+    ],
+    "spriteSourceSize": [
+      154,
+      80
+    ],
+    "textureRect": [
+      [
+        3896,
+        1614
+      ],
+      [
+        154,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      138,
+      58
+    ],
+    "spriteSourceSize": [
+      138,
+      58
+    ],
+    "textureRect": [
+      [
+        1193,
+        1316
+      ],
+      [
+        138,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_02_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      123,
+      78
+    ],
+    "spriteSourceSize": [
+      123,
+      196
+    ],
+    "textureRect": [
+      [
+        642,
+        1309
+      ],
+      [
+        123,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      150,
+      66
+    ],
+    "spriteSourceSize": [
+      150,
+      68
+    ],
+    "textureRect": [
+      [
+        722,
+        491
+      ],
+      [
+        150,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      144,
+      58
+    ],
+    "spriteSourceSize": [
+      144,
+      58
+    ],
+    "textureRect": [
+      [
+        871,
+        716
+      ],
+      [
+        144,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_03_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      123,
+      78
+    ],
+    "spriteSourceSize": [
+      123,
+      196
+    ],
+    "textureRect": [
+      [
+        642,
+        1309
+      ],
+      [
+        123,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      157,
+      66
+    ],
+    "spriteSourceSize": [
+      157,
+      66
+    ],
+    "textureRect": [
+      [
+        3741,
+        1359
+      ],
+      [
+        157,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      134,
+      60
+    ],
+    "spriteSourceSize": [
+      134,
+      60
+    ],
+    "textureRect": [
+      [
+        1745,
+        1364
+      ],
+      [
+        134,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_04_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      123,
+      78
+    ],
+    "spriteSourceSize": [
+      123,
+      196
+    ],
+    "textureRect": [
+      [
+        642,
+        1309
+      ],
+      [
+        123,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_05_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      150,
+      78
+    ],
+    "spriteSourceSize": [
+      150,
+      90
+    ],
+    "textureRect": [
+      [
+        504,
+        534
+      ],
+      [
+        150,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_05_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      120,
+      54
+    ],
+    "spriteSourceSize": [
+      120,
+      58
+    ],
+    "textureRect": [
+      [
+        1451,
+        1973
+      ],
+      [
+        120,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_05_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      123,
+      78
+    ],
+    "spriteSourceSize": [
+      123,
+      196
+    ],
+    "textureRect": [
+      [
+        642,
+        1309
+      ],
+      [
+        123,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_06_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      148,
+      76
+    ],
+    "spriteSourceSize": [
+      148,
+      88
+    ],
+    "textureRect": [
+      [
+        722,
+        649
+      ],
+      [
+        148,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_06_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      144,
+      72
+    ],
+    "spriteSourceSize": [
+      144,
+      84
+    ],
+    "textureRect": [
+      [
+        1,
+        853
+      ],
+      [
+        144,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_06_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      123,
+      78
+    ],
+    "spriteSourceSize": [
+      123,
+      196
+    ],
+    "textureRect": [
+      [
+        642,
+        1309
+      ],
+      [
+        123,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_07_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      142,
+      68
+    ],
+    "spriteSourceSize": [
+      142,
+      68
+    ],
+    "textureRect": [
+      [
+        1,
+        987
+      ],
+      [
+        142,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_07_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      136,
+      52
+    ],
+    "spriteSourceSize": [
+      136,
+      56
+    ],
+    "textureRect": [
+      [
+        2112,
+        436
+      ],
+      [
+        136,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_07_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      123,
+      78
+    ],
+    "spriteSourceSize": [
+      123,
+      196
+    ],
+    "textureRect": [
+      [
+        642,
+        1309
+      ],
+      [
+        123,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_08_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      148,
+      68
+    ],
+    "spriteSourceSize": [
+      148,
+      68
+    ],
+    "textureRect": [
+      [
+        1194,
+        725
+      ],
+      [
+        148,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_08_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      141,
+      50
+    ],
+    "spriteSourceSize": [
+      141,
+      62
+    ],
+    "textureRect": [
+      [
+        451,
+        1122
+      ],
+      [
+        141,
+        50
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_08_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      56
+    ],
+    "spriteSize": [
+      123,
+      84
+    ],
+    "spriteSourceSize": [
+      123,
+      196
+    ],
+    "textureRect": [
+      [
+        3249,
+        1641
+      ],
+      [
+        123,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_09_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      153,
+      68
+    ],
+    "spriteSourceSize": [
+      153,
+      70
+    ],
+    "textureRect": [
+      [
+        3739,
+        1712
+      ],
+      [
+        153,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_09_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      144,
+      56
+    ],
+    "spriteSourceSize": [
+      144,
+      58
+    ],
+    "textureRect": [
+      [
+        722,
+        726
+      ],
+      [
+        144,
+        56
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_09_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1115,
+        2672
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_10_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      118,
+      72
+    ],
+    "spriteSourceSize": [
+      118,
+      74
+    ],
+    "textureRect": [
+      [
+        157,
+        2756
+      ],
+      [
+        118,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_10_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      104,
+      60
+    ],
+    "spriteSourceSize": [
+      104,
+      60
+    ],
+    "textureRect": [
+      [
+        1053,
+        2732
+      ],
+      [
+        104,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_10_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1115,
+        2672
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_11_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      132,
+      72
+    ],
+    "spriteSourceSize": [
+      132,
+      78
+    ],
+    "textureRect": [
+      [
+        649,
+        835
+      ],
+      [
+        132,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_11_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      14
+    ],
+    "spriteSize": [
+      82,
+      14
+    ],
+    "spriteSourceSize": [
+      82,
+      42
+    ],
+    "textureRect": [
+      [
+        1334,
+        1087
+      ],
+      [
+        82,
+        14
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_11_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1114,
+        2745
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_12_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      5
+    ],
+    "spriteSize": [
+      140,
+      66
+    ],
+    "spriteSourceSize": [
+      140,
+      76
+    ],
+    "textureRect": [
+      [
+        721,
+        1416
+      ],
+      [
+        140,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_12_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -2
+    ],
+    "spriteSize": [
+      132,
+      44
+    ],
+    "spriteSourceSize": [
+      132,
+      48
+    ],
+    "textureRect": [
+      [
+        4050,
+        1758
+      ],
+      [
+        132,
+        44
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_12_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1114,
+        2745
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_13_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      146,
+      62
+    ],
+    "spriteSourceSize": [
+      146,
+      62
+    ],
+    "textureRect": [
+      [
+        1,
+        693
+      ],
+      [
+        146,
+        62
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_13_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      8
+    ],
+    "spriteSize": [
+      138,
+      30
+    ],
+    "spriteSourceSize": [
+      138,
+      46
+    ],
+    "textureRect": [
+      [
+        3526,
+        596
+      ],
+      [
+        138,
+        30
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_13_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1114,
+        2745
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_14_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      148,
+      78
+    ],
+    "spriteSourceSize": [
+      148,
+      92
+    ],
+    "textureRect": [
+      [
+        873,
+        548
+      ],
+      [
+        148,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_14_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      18
+    ],
+    "spriteSize": [
+      128,
+      50
+    ],
+    "spriteSourceSize": [
+      128,
+      86
+    ],
+    "textureRect": [
+      [
+        450,
+        1264
+      ],
+      [
+        128,
+        50
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_14_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1114,
+        2745
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_15_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      13
+    ],
+    "spriteSize": [
+      140,
+      92
+    ],
+    "spriteSourceSize": [
+      140,
+      118
+    ],
+    "textureRect": [
+      [
+        1004,
+        1337
+      ],
+      [
+        140,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_15_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      56
+    ],
+    "spriteSourceSize": [
+      110,
+      56
+    ],
+    "textureRect": [
+      [
+        2568,
+        1339
+      ],
+      [
+        110,
+        56
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_15_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1114,
+        2745
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_16_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      158,
+      78
+    ],
+    "spriteSourceSize": [
+      158,
+      92
+    ],
+    "textureRect": [
+      [
+        3557,
+        1333
+      ],
+      [
+        158,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_16_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      10
+    ],
+    "spriteSize": [
+      122,
+      66
+    ],
+    "spriteSourceSize": [
+      122,
+      86
+    ],
+    "textureRect": [
+      [
+        2557,
+        1556
+      ],
+      [
+        122,
+        66
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_16_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1114,
+        2745
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_17_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      15
+    ],
+    "spriteSize": [
+      136,
+      96
+    ],
+    "spriteSourceSize": [
+      136,
+      126
+    ],
+    "textureRect": [
+      [
+        1193,
+        1375
+      ],
+      [
+        136,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_17_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      25
+    ],
+    "spriteSize": [
+      120,
+      72
+    ],
+    "spriteSourceSize": [
+      120,
+      122
+    ],
+    "textureRect": [
+      [
+        1257,
+        1732
+      ],
+      [
+        120,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_17_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1114,
+        2745
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_18_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      8
+    ],
+    "spriteSize": [
+      160,
+      78
+    ],
+    "spriteSourceSize": [
+      160,
+      94
+    ],
+    "textureRect": [
+      [
+        2465,
+        1147
+      ],
+      [
+        160,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_18_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      88,
+      66
+    ],
+    "spriteSourceSize": [
+      88,
+      74
+    ],
+    "textureRect": [
+      [
+        2434,
+        2696
+      ],
+      [
+        88,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_18_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      61
+    ],
+    "spriteSize": [
+      106,
+      72
+    ],
+    "spriteSourceSize": [
+      106,
+      194
+    ],
+    "textureRect": [
+      [
+        1114,
+        2745
+      ],
+      [
+        106,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_19_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -3
+    ],
+    "spriteSize": [
+      148,
+      72
+    ],
+    "spriteSourceSize": [
+      148,
+      78
+    ],
+    "textureRect": [
+      [
+        1022,
+        643
+      ],
+      [
+        148,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_19_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -7
+    ],
+    "spriteSize": [
+      144,
+      60
+    ],
+    "spriteSourceSize": [
+      144,
+      74
+    ],
+    "textureRect": [
+      [
+        1,
+        926
+      ],
+      [
+        144,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_19_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_20_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      156,
+      76
+    ],
+    "spriteSourceSize": [
+      156,
+      84
+    ],
+    "textureRect": [
+      [
+        3741,
+        1426
+      ],
+      [
+        156,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_20_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      153,
+      72
+    ],
+    "spriteSourceSize": [
+      153,
+      80
+    ],
+    "textureRect": [
+      [
+        3896,
+        1689
+      ],
+      [
+        153,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_20_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_20_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -9
+    ],
+    "spriteSize": [
+      90,
+      48
+    ],
+    "spriteSourceSize": [
+      90,
+      66
+    ],
+    "textureRect": [
+      [
+        2288,
+        2289
+      ],
+      [
+        90,
+        48
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_21_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -7
+    ],
+    "spriteSize": [
+      128,
+      100
+    ],
+    "spriteSourceSize": [
+      128,
+      114
+    ],
+    "textureRect": [
+      [
+        3148,
+        1151
+      ],
+      [
+        128,
+        100
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_21_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -22
+    ],
+    "spriteSize": [
+      92,
+      68
+    ],
+    "spriteSourceSize": [
+      92,
+      112
+    ],
+    "textureRect": [
+      [
+        3486,
+        2760
+      ],
+      [
+        92,
+        68
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_21_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_21_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      96,
+      70
+    ],
+    "spriteSourceSize": [
+      96,
+      70
+    ],
+    "textureRect": [
+      [
+        1221,
+        2847
+      ],
+      [
+        96,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_22_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      180,
+      72
+    ],
+    "spriteSourceSize": [
+      180,
+      76
+    ],
+    "textureRect": [
+      [
+        2775,
+        306
+      ],
+      [
+        180,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_22_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -10
+    ],
+    "spriteSize": [
+      108,
+      34
+    ],
+    "spriteSourceSize": [
+      108,
+      54
+    ],
+    "textureRect": [
+      [
+        1197,
+        212
+      ],
+      [
+        108,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_22_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_22_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      13
+    ],
+    "spriteSize": [
+      74,
+      50
+    ],
+    "spriteSourceSize": [
+      74,
+      76
+    ],
+    "textureRect": [
+      [
+        3264,
+        2922
+      ],
+      [
+        74,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_23_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      136,
+      70
+    ],
+    "spriteSourceSize": [
+      136,
+      72
+    ],
+    "textureRect": [
+      [
+        721,
+        1483
+      ],
+      [
+        136,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_23_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -3
+    ],
+    "spriteSize": [
+      132,
+      54
+    ],
+    "spriteSourceSize": [
+      132,
+      60
+    ],
+    "textureRect": [
+      [
+        2436,
+        1226
+      ],
+      [
+        132,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_23_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      116,
+      78
+    ],
+    "spriteSourceSize": [
+      116,
+      196
+    ],
+    "textureRect": [
+      [
+        1570,
+        2081
+      ],
+      [
+        116,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_23_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      5
+    ],
+    "spriteSize": [
+      92,
+      20
+    ],
+    "spriteSourceSize": [
+      92,
+      30
+    ],
+    "textureRect": [
+      [
+        3228,
+        314
+      ],
+      [
+        92,
+        20
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_24_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      164,
+      68
+    ],
+    "spriteSourceSize": [
+      164,
+      68
+    ],
+    "textureRect": [
+      [
+        2887,
+        1054
+      ],
+      [
+        164,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_24_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      160,
+      64
+    ],
+    "spriteSourceSize": [
+      160,
+      64
+    ],
+    "textureRect": [
+      [
+        2887,
+        1123
+      ],
+      [
+        160,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_24_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_24_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      14
+    ],
+    "spriteSize": [
+      128,
+      14
+    ],
+    "spriteSourceSize": [
+      128,
+      42
+    ],
+    "textureRect": [
+      [
+        1496,
+        1056
+      ],
+      [
+        128,
+        14
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_25_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      136,
+      68
+    ],
+    "spriteSourceSize": [
+      136,
+      68
+    ],
+    "textureRect": [
+      [
+        858,
+        1512
+      ],
+      [
+        136,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_25_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      132,
+      64
+    ],
+    "spriteSourceSize": [
+      132,
+      64
+    ],
+    "textureRect": [
+      [
+        991,
+        1622
+      ],
+      [
+        132,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_25_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_25_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      122,
+      52
+    ],
+    "spriteSourceSize": [
+      122,
+      60
+    ],
+    "textureRect": [
+      [
+        2112,
+        835
+      ],
+      [
+        122,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_26_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      130,
+      82
+    ],
+    "spriteSourceSize": [
+      130,
+      90
+    ],
+    "textureRect": [
+      [
+        1463,
+        1640
+      ],
+      [
+        130,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_26_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      12
+    ],
+    "spriteSize": [
+      114,
+      62
+    ],
+    "spriteSourceSize": [
+      114,
+      86
+    ],
+    "textureRect": [
+      [
+        3493,
+        2012
+      ],
+      [
+        114,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_26_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_26_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      10
+    ],
+    "spriteSize": [
+      114,
+      58
+    ],
+    "spriteSourceSize": [
+      114,
+      78
+    ],
+    "textureRect": [
+      [
+        3680,
+        1734
+      ],
+      [
+        114,
+        58
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_27_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      156,
+      68
+    ],
+    "spriteSourceSize": [
+      156,
+      68
+    ],
+    "textureRect": [
+      [
+        3898,
+        1472
+      ],
+      [
+        156,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_27_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -5
+    ],
+    "spriteSize": [
+      128,
+      54
+    ],
+    "spriteSourceSize": [
+      128,
+      64
+    ],
+    "textureRect": [
+      [
+        2138,
+        1631
+      ],
+      [
+        128,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_27_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      52
+    ],
+    "spriteSize": [
+      122,
+      92
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3249,
+        1791
+      ],
+      [
+        122,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_27_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      82,
+      38
+    ],
+    "spriteSourceSize": [
+      82,
+      46
+    ],
+    "textureRect": [
+      [
+        2848,
+        246
+      ],
+      [
+        82,
+        38
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_28_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      144,
+      96
+    ],
+    "spriteSourceSize": [
+      144,
+      110
+    ],
+    "textureRect": [
+      [
+        1,
+        756
+      ],
+      [
+        144,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_28_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      8
+    ],
+    "spriteSize": [
+      140,
+      90
+    ],
+    "spriteSourceSize": [
+      140,
+      106
+    ],
+    "textureRect": [
+      [
+        862,
+        1340
+      ],
+      [
+        140,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_28_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_28_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      136,
+      80
+    ],
+    "spriteSourceSize": [
+      136,
+      94
+    ],
+    "textureRect": [
+      [
+        862,
+        1431
+      ],
+      [
+        136,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_29_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      10
+    ],
+    "spriteSize": [
+      148,
+      84
+    ],
+    "spriteSourceSize": [
+      148,
+      104
+    ],
+    "textureRect": [
+      [
+        3408,
+        1417
+      ],
+      [
+        148,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_29_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      8
+    ],
+    "spriteSize": [
+      138,
+      76
+    ],
+    "spriteSourceSize": [
+      138,
+      92
+    ],
+    "textureRect": [
+      [
+        644,
+        1170
+      ],
+      [
+        138,
+        76
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_29_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_29_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      11
+    ],
+    "spriteSize": [
+      132,
+      56
+    ],
+    "spriteSourceSize": [
+      132,
+      78
+    ],
+    "textureRect": [
+      [
+        1273,
+        1472
+      ],
+      [
+        132,
+        56
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_30_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      21
+    ],
+    "spriteSize": [
+      154,
+      114
+    ],
+    "spriteSourceSize": [
+      154,
+      156
+    ],
+    "textureRect": [
+      [
+        907,
+        254
+      ],
+      [
+        154,
+        114
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_30_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      20
+    ],
+    "spriteSize": [
+      152,
+      108
+    ],
+    "spriteSourceSize": [
+      152,
+      148
+    ],
+    "textureRect": [
+      [
+        3249,
+        1532
+      ],
+      [
+        152,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_30_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      53
+    ],
+    "spriteSize": [
+      116,
+      92
+    ],
+    "spriteSourceSize": [
+      116,
+      198
+    ],
+    "textureRect": [
+      [
+        3733,
+        2870
+      ],
+      [
+        116,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_30_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      112,
+      56
+    ],
+    "spriteSourceSize": [
+      112,
+      56
+    ],
+    "textureRect": [
+      [
+        2569,
+        1226
+      ],
+      [
+        112,
+        56
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_31_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      152,
+      68
+    ],
+    "spriteSourceSize": [
+      152,
+      74
+    ],
+    "textureRect": [
+      [
+        506,
+        392
+      ],
+      [
+        152,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_31_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      136,
+      66
+    ],
+    "spriteSourceSize": [
+      136,
+      72
+    ],
+    "textureRect": [
+      [
+        721,
+        1554
+      ],
+      [
+        136,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_31_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_32_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      144,
+      84
+    ],
+    "spriteSourceSize": [
+      144,
+      98
+    ],
+    "textureRect": [
+      [
+        317,
+        811
+      ],
+      [
+        144,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_32_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      112,
+      60
+    ],
+    "spriteSourceSize": [
+      112,
+      68
+    ],
+    "textureRect": [
+      [
+        3496,
+        1832
+      ],
+      [
+        112,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_32_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      53
+    ],
+    "spriteSize": [
+      116,
+      92
+    ],
+    "spriteSourceSize": [
+      116,
+      198
+    ],
+    "textureRect": [
+      [
+        3733,
+        2870
+      ],
+      [
+        116,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_32_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      9
+    ],
+    "spriteSize": [
+      140,
+      70
+    ],
+    "spriteSourceSize": [
+      140,
+      88
+    ],
+    "textureRect": [
+      [
+        651,
+        694
+      ],
+      [
+        140,
+        70
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_33_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      13
+    ],
+    "spriteSize": [
+      152,
+      102
+    ],
+    "spriteSourceSize": [
+      152,
+      128
+    ],
+    "textureRect": [
+      [
+        3045,
+        1368
+      ],
+      [
+        152,
+        102
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_33_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -4
+    ],
+    "spriteSize": [
+      144,
+      54
+    ],
+    "spriteSourceSize": [
+      144,
+      62
+    ],
+    "textureRect": [
+      [
+        1016,
+        716
+      ],
+      [
+        144,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_33_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_33_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      42,
+      22
+    ],
+    "spriteSourceSize": [
+      42,
+      34
+    ],
+    "textureRect": [
+      [
+        143,
+        1083
+      ],
+      [
+        42,
+        22
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_34_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      9
+    ],
+    "spriteSize": [
+      150,
+      90
+    ],
+    "spriteSourceSize": [
+      150,
+      108
+    ],
+    "textureRect": [
+      [
+        353,
+        467
+      ],
+      [
+        150,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_34_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      9
+    ],
+    "spriteSize": [
+      144,
+      82
+    ],
+    "spriteSourceSize": [
+      144,
+      100
+    ],
+    "textureRect": [
+      [
+        169,
+        836
+      ],
+      [
+        144,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_34_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_34_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      138,
+      58
+    ],
+    "spriteSourceSize": [
+      138,
+      62
+    ],
+    "textureRect": [
+      [
+        1793,
+        1198
+      ],
+      [
+        138,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_35_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      68
+    ],
+    "spriteSourceSize": [
+      140,
+      68
+    ],
+    "textureRect": [
+      [
+        721,
+        1347
+      ],
+      [
+        140,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_35_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      132,
+      52
+    ],
+    "spriteSourceSize": [
+      132,
+      56
+    ],
+    "textureRect": [
+      [
+        2112,
+        573
+      ],
+      [
+        132,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "bird_35_3_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      59
+    ],
+    "spriteSize": [
+      122,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      196
+    ],
+    "textureRect": [
+      [
+        3372,
+        1882
+      ],
+      [
+        122,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "bird_35_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      128,
+      40
+    ],
+    "spriteSourceSize": [
+      128,
+      48
+    ],
+    "textureRect": [
+      [
+        4055,
+        1481
+      ],
+      [
+        128,
+        40
+      ]
+    ],
+    "textureRotated": true
+  },
+  "boost_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      174
+    ],
+    "spriteSourceSize": [
+      140,
+      174
+    ],
+    "textureRect": [
+      [
+        178,
+        337
+      ],
+      [
+        140,
+        174
+      ]
+    ],
+    "textureRotated": true
+  },
+  "boost_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      132,
+      226
+    ],
+    "spriteSourceSize": [
+      132,
+      226
+    ],
+    "textureRect": [
+      [
+        3557,
+        761
+      ],
+      [
+        132,
+        226
+      ]
+    ],
+    "textureRotated": true
+  },
+  "boost_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      202,
+      226
+    ],
+    "spriteSourceSize": [
+      202,
+      226
+    ],
+    "textureRect": [
+      [
+        3558,
+        558
+      ],
+      [
+        202,
+        226
+      ]
+    ],
+    "textureRotated": true
+  },
+  "boost_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      260,
+      226
+    ],
+    "spriteSourceSize": [
+      260,
+      226
+    ],
+    "textureRect": [
+      [
+        2887,
+        657
+      ],
+      [
+        260,
+        226
+      ]
+    ],
+    "textureRotated": false
+  },
+  "boost_05_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      276,
+      226
+    ],
+    "spriteSourceSize": [
+      276,
+      226
+    ],
+    "textureRect": [
+      [
+        3249,
+        511
+      ],
+      [
+        276,
+        226
+      ]
+    ],
+    "textureRotated": false
+  },
+  "checkpoint_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      68,
+      126
+    ],
+    "spriteSourceSize": [
+      68,
+      126
+    ],
+    "textureRect": [
+      [
+        1261,
+        1605
+      ],
+      [
+        68,
+        126
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      102,
+      82
+    ],
+    "spriteSourceSize": [
+      102,
+      82
+    ],
+    "textureRect": [
+      [
+        714,
+        2973
+      ],
+      [
+        102,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -32,
+      0
+    ],
+    "spriteSize": [
+      20,
+      40
+    ],
+    "spriteSourceSize": [
+      84,
+      40
+    ],
+    "textureRect": [
+      [
+        873,
+        422
+      ],
+      [
+        20,
+        40
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      102,
+      82
+    ],
+    "spriteSourceSize": [
+      102,
+      82
+    ],
+    "textureRect": [
+      [
+        492,
+        3005
+      ],
+      [
+        102,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -12,
+      0
+    ],
+    "spriteSize": [
+      60,
+      40
+    ],
+    "spriteSourceSize": [
+      84,
+      40
+    ],
+    "textureRect": [
+      [
+        2822,
+        2911
+      ],
+      [
+        60,
+        40
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      0
+    ],
+    "spriteSize": [
+      116,
+      82
+    ],
+    "spriteSourceSize": [
+      128,
+      82
+    ],
+    "textureRect": [
+      [
+        3967,
+        3024
+      ],
+      [
+        116,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -8,
+      0
+    ],
+    "spriteSize": [
+      98,
+      44
+    ],
+    "spriteSourceSize": [
+      114,
+      44
+    ],
+    "textureRect": [
+      [
+        457,
+        934
+      ],
+      [
+        98,
+        44
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      104,
+      82
+    ],
+    "spriteSourceSize": [
+      104,
+      82
+    ],
+    "textureRect": [
+      [
+        1221,
+        2764
+      ],
+      [
+        104,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      84,
+      62
+    ],
+    "spriteSourceSize": [
+      88,
+      62
+    ],
+    "textureRect": [
+      [
+        3493,
+        2521
+      ],
+      [
+        84,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_05_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      0
+    ],
+    "spriteSize": [
+      116,
+      80
+    ],
+    "spriteSourceSize": [
+      126,
+      80
+    ],
+    "textureRect": [
+      [
+        2961,
+        2483
+      ],
+      [
+        116,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_05_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      0
+    ],
+    "spriteSize": [
+      96,
+      50
+    ],
+    "spriteSourceSize": [
+      108,
+      50
+    ],
+    "textureRect": [
+      [
+        1114,
+        2873
+      ],
+      [
+        96,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_06_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      0
+    ],
+    "spriteSize": [
+      118,
+      82
+    ],
+    "spriteSourceSize": [
+      130,
+      82
+    ],
+    "textureRect": [
+      [
+        719,
+        2468
+      ],
+      [
+        118,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_06_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -29,
+      0
+    ],
+    "spriteSize": [
+      66,
+      40
+    ],
+    "spriteSourceSize": [
+      124,
+      40
+    ],
+    "textureRect": [
+      [
+        462,
+        867
+      ],
+      [
+        66,
+        40
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_07_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      112,
+      82
+    ],
+    "spriteSourceSize": [
+      120,
+      82
+    ],
+    "textureRect": [
+      [
+        1687,
+        2081
+      ],
+      [
+        112,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_07_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      0
+    ],
+    "spriteSize": [
+      58,
+      20
+    ],
+    "spriteSourceSize": [
+      70,
+      20
+    ],
+    "textureRect": [
+      [
+        3228,
+        407
+      ],
+      [
+        58,
+        20
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_08_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      0
+    ],
+    "spriteSize": [
+      104,
+      96
+    ],
+    "spriteSourceSize": [
+      114,
+      96
+    ],
+    "textureRect": [
+      [
+        3042,
+        2527
+      ],
+      [
+        104,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_08_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -19,
+      0
+    ],
+    "spriteSize": [
+      70,
+      36
+    ],
+    "spriteSourceSize": [
+      108,
+      36
+    ],
+    "textureRect": [
+      [
+        3007,
+        1697
+      ],
+      [
+        70,
+        36
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_09_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      108,
+      82
+    ],
+    "spriteSourceSize": [
+      110,
+      82
+    ],
+    "textureRect": [
+      [
+        1549,
+        2528
+      ],
+      [
+        108,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_09_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -18,
+      0
+    ],
+    "spriteSize": [
+      66,
+      42
+    ],
+    "spriteSourceSize": [
+      102,
+      42
+    ],
+    "textureRect": [
+      [
+        3732,
+        3056
+      ],
+      [
+        66,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_10_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      102,
+      82
+    ],
+    "spriteSourceSize": [
+      102,
+      82
+    ],
+    "textureRect": [
+      [
+        374,
+        3053
+      ],
+      [
+        102,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_10_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -9,
+      0
+    ],
+    "spriteSize": [
+      74,
+      50
+    ],
+    "spriteSourceSize": [
+      92,
+      50
+    ],
+    "textureRect": [
+      [
+        3555,
+        2930
+      ],
+      [
+        74,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_11_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      102,
+      82
+    ],
+    "spriteSourceSize": [
+      102,
+      82
+    ],
+    "textureRect": [
+      [
+        258,
+        3107
+      ],
+      [
+        102,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_11_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      88,
+      30
+    ],
+    "spriteSourceSize": [
+      88,
+      30
+    ],
+    "textureRect": [
+      [
+        3526,
+        735
+      ],
+      [
+        88,
+        30
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_12_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      102,
+      76
+    ],
+    "spriteSourceSize": [
+      110,
+      76
+    ],
+    "textureRect": [
+      [
+        595,
+        3011
+      ],
+      [
+        102,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_12_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -24,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      94,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3220
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_13_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      102,
+      86
+    ],
+    "spriteSourceSize": [
+      102,
+      86
+    ],
+    "textureRect": [
+      [
+        611,
+        2924
+      ],
+      [
+        102,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_13_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -12,
+      0
+    ],
+    "spriteSize": [
+      38,
+      34
+    ],
+    "spriteSourceSize": [
+      62,
+      34
+    ],
+    "textureRect": [
+      [
+        1084,
+        1925
+      ],
+      [
+        38,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_14_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      106,
+      88
+    ],
+    "spriteSourceSize": [
+      106,
+      88
+    ],
+    "textureRect": [
+      [
+        1326,
+        2661
+      ],
+      [
+        106,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_14_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -26,
+      0
+    ],
+    "spriteSize": [
+      50,
+      62
+    ],
+    "spriteSourceSize": [
+      102,
+      62
+    ],
+    "textureRect": [
+      [
+        3915,
+        3128
+      ],
+      [
+        50,
+        62
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_15_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      104,
+      84
+    ],
+    "spriteSourceSize": [
+      106,
+      84
+    ],
+    "textureRect": [
+      [
+        3264,
+        2701
+      ],
+      [
+        104,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_15_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      0
+    ],
+    "spriteSize": [
+      85,
+      78
+    ],
+    "spriteSourceSize": [
+      95,
+      78
+    ],
+    "textureRect": [
+      [
+        1532,
+        2811
+      ],
+      [
+        85,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_16_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      106,
+      86
+    ],
+    "spriteSourceSize": [
+      110,
+      86
+    ],
+    "textureRect": [
+      [
+        1326,
+        2750
+      ],
+      [
+        106,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_16_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -8,
+      0
+    ],
+    "spriteSize": [
+      90,
+      82
+    ],
+    "spriteSourceSize": [
+      106,
+      82
+    ],
+    "textureRect": [
+      [
+        2055,
+        2635
+      ],
+      [
+        90,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_17_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      104,
+      90
+    ],
+    "spriteSourceSize": [
+      106,
+      90
+    ],
+    "textureRect": [
+      [
+        3264,
+        2610
+      ],
+      [
+        104,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_17_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      71,
+      60
+    ],
+    "spriteSourceSize": [
+      71,
+      60
+    ],
+    "textureRect": [
+      [
+        3671,
+        2978
+      ],
+      [
+        71,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_18_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      108,
+      80
+    ],
+    "spriteSourceSize": [
+      110,
+      80
+    ],
+    "textureRect": [
+      [
+        640,
+        1595
+      ],
+      [
+        108,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_18_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      104,
+      52
+    ],
+    "spriteSourceSize": [
+      106,
+      52
+    ],
+    "textureRect": [
+      [
+        2990,
+        2122
+      ],
+      [
+        104,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_19_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      0
+    ],
+    "spriteSize": [
+      96,
+      92
+    ],
+    "spriteSourceSize": [
+      108,
+      92
+    ],
+    "textureRect": [
+      [
+        1326,
+        2837
+      ],
+      [
+        96,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_19_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -15,
+      0
+    ],
+    "spriteSize": [
+      70,
+      84
+    ],
+    "spriteSourceSize": [
+      100,
+      84
+    ],
+    "textureRect": [
+      [
+        2494,
+        2796
+      ],
+      [
+        70,
+        84
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_20_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      106,
+      80
+    ],
+    "spriteSourceSize": [
+      108,
+      80
+    ],
+    "textureRect": [
+      [
+        640,
+        1704
+      ],
+      [
+        106,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_20_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      0
+    ],
+    "spriteSize": [
+      48,
+      18
+    ],
+    "spriteSourceSize": [
+      62,
+      18
+    ],
+    "textureRect": [
+      [
+        1498,
+        847
+      ],
+      [
+        48,
+        18
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_21_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      102,
+      88
+    ],
+    "spriteSourceSize": [
+      104,
+      88
+    ],
+    "textureRect": [
+      [
+        716,
+        2884
+      ],
+      [
+        102,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_21_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      58,
+      34
+    ],
+    "spriteSourceSize": [
+      66,
+      34
+    ],
+    "textureRect": [
+      [
+        3677,
+        2650
+      ],
+      [
+        58,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_22_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      0
+    ],
+    "spriteSize": [
+      102,
+      70
+    ],
+    "spriteSourceSize": [
+      116,
+      70
+    ],
+    "textureRect": [
+      [
+        1043,
+        2837
+      ],
+      [
+        102,
+        70
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_22_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      0
+    ],
+    "spriteSize": [
+      94,
+      62
+    ],
+    "spriteSourceSize": [
+      108,
+      62
+    ],
+    "textureRect": [
+      [
+        3493,
+        2335
+      ],
+      [
+        94,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_23_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      110,
+      84
+    ],
+    "spriteSourceSize": [
+      112,
+      84
+    ],
+    "textureRect": [
+      [
+        1955,
+        2285
+      ],
+      [
+        110,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_23_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      102,
+      74
+    ],
+    "spriteSourceSize": [
+      104,
+      74
+    ],
+    "textureRect": [
+      [
+        2337,
+        2388
+      ],
+      [
+        102,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_24_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      102,
+      80
+    ],
+    "spriteSourceSize": [
+      106,
+      80
+    ],
+    "textureRect": [
+      [
+        640,
+        2021
+      ],
+      [
+        102,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_24_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      94,
+      74
+    ],
+    "spriteSourceSize": [
+      96,
+      74
+    ],
+    "textureRect": [
+      [
+        1767,
+        2630
+      ],
+      [
+        94,
+        74
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_24_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      16,
+      0
+    ],
+    "spriteSize": [
+      47,
+      6
+    ],
+    "spriteSourceSize": [
+      79,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        32
+      ],
+      [
+        47,
+        6
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_25_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      104,
+      74
+    ],
+    "spriteSourceSize": [
+      106,
+      78
+    ],
+    "textureRect": [
+      [
+        932,
+        2892
+      ],
+      [
+        104,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_25_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      0
+    ],
+    "spriteSize": [
+      65,
+      62
+    ],
+    "spriteSourceSize": [
+      79,
+      62
+    ],
+    "textureRect": [
+      [
+        1780,
+        2396
+      ],
+      [
+        65,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_26_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      104,
+      80
+    ],
+    "spriteSourceSize": [
+      108,
+      80
+    ],
+    "textureRect": [
+      [
+        640,
+        1811
+      ],
+      [
+        104,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_26_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      0
+    ],
+    "spriteSize": [
+      50,
+      60
+    ],
+    "spriteSourceSize": [
+      62,
+      60
+    ],
+    "textureRect": [
+      [
+        3670,
+        3176
+      ],
+      [
+        50,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_27_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      108,
+      72
+    ],
+    "spriteSourceSize": [
+      108,
+      80
+    ],
+    "textureRect": [
+      [
+        1326,
+        2588
+      ],
+      [
+        108,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_27_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      0
+    ],
+    "spriteSize": [
+      50,
+      48
+    ],
+    "spriteSourceSize": [
+      54,
+      48
+    ],
+    "textureRect": [
+      [
+        1789,
+        2796
+      ],
+      [
+        50,
+        48
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_28_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      95,
+      84
+    ],
+    "spriteSourceSize": [
+      95,
+      84
+    ],
+    "textureRect": [
+      [
+        1114,
+        2924
+      ],
+      [
+        95,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_28_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      0
+    ],
+    "spriteSize": [
+      72,
+      48
+    ],
+    "spriteSourceSize": [
+      82,
+      48
+    ],
+    "textureRect": [
+      [
+        3177,
+        2976
+      ],
+      [
+        72,
+        48
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_29_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      108,
+      82
+    ],
+    "spriteSourceSize": [
+      114,
+      82
+    ],
+    "textureRect": [
+      [
+        1439,
+        2568
+      ],
+      [
+        108,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_29_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      0
+    ],
+    "spriteSize": [
+      94,
+      76
+    ],
+    "spriteSourceSize": [
+      106,
+      76
+    ],
+    "textureRect": [
+      [
+        1037,
+        2940
+      ],
+      [
+        94,
+        76
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_29_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -12,
+      0
+    ],
+    "spriteSize": [
+      48,
+      20
+    ],
+    "spriteSourceSize": [
+      72,
+      20
+    ],
+    "textureRect": [
+      [
+        3720,
+        1286
+      ],
+      [
+        48,
+        20
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_30_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      100,
+      66
+    ],
+    "spriteSourceSize": [
+      100,
+      66
+    ],
+    "textureRect": [
+      [
+        3148,
+        2265
+      ],
+      [
+        100,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_30_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      86,
+      60
+    ],
+    "spriteSourceSize": [
+      92,
+      60
+    ],
+    "textureRect": [
+      [
+        2322,
+        2729
+      ],
+      [
+        86,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_30_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      0
+    ],
+    "spriteSize": [
+      11,
+      12
+    ],
+    "spriteSourceSize": [
+      23,
+      12
+    ],
+    "textureRect": [
+      [
+        2755,
+        589
+      ],
+      [
+        11,
+        12
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_31_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      0
+    ],
+    "spriteSize": [
+      116,
+      86
+    ],
+    "spriteSourceSize": [
+      130,
+      86
+    ],
+    "textureRect": [
+      [
+        3850,
+        2976
+      ],
+      [
+        116,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_31_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -8,
+      0
+    ],
+    "spriteSize": [
+      108,
+      74
+    ],
+    "spriteSourceSize": [
+      124,
+      74
+    ],
+    "textureRect": [
+      [
+        565,
+        1674
+      ],
+      [
+        108,
+        74
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_31_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -22,
+      0
+    ],
+    "spriteSize": [
+      8,
+      16
+    ],
+    "spriteSourceSize": [
+      52,
+      16
+    ],
+    "textureRect": [
+      [
+        3558,
+        8
+      ],
+      [
+        8,
+        16
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_32_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      95,
+      80
+    ],
+    "spriteSourceSize": [
+      95,
+      80
+    ],
+    "textureRect": [
+      [
+        640,
+        2124
+      ],
+      [
+        95,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_32_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      87,
+      74
+    ],
+    "spriteSourceSize": [
+      87,
+      74
+    ],
+    "textureRect": [
+      [
+        2626,
+        2595
+      ],
+      [
+        87,
+        74
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_32_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      0
+    ],
+    "spriteSize": [
+      53,
+      16
+    ],
+    "spriteSourceSize": [
+      63,
+      16
+    ],
+    "textureRect": [
+      [
+        2112,
+        278
+      ],
+      [
+        53,
+        16
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_33_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      108,
+      72
+    ],
+    "spriteSourceSize": [
+      114,
+      72
+    ],
+    "textureRect": [
+      [
+        1658,
+        2599
+      ],
+      [
+        108,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_33_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      0
+    ],
+    "spriteSize": [
+      98,
+      64
+    ],
+    "spriteSourceSize": [
+      110,
+      64
+    ],
+    "textureRect": [
+      [
+        1778,
+        2462
+      ],
+      [
+        98,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_33_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      10,
+      0
+    ],
+    "spriteSize": [
+      59,
+      62
+    ],
+    "spriteSourceSize": [
+      79,
+      62
+    ],
+    "textureRect": [
+      [
+        3497,
+        1769
+      ],
+      [
+        59,
+        62
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_34_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      112,
+      70
+    ],
+    "spriteSourceSize": [
+      120,
+      70
+    ],
+    "textureRect": [
+      [
+        1679,
+        2164
+      ],
+      [
+        112,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_34_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      9,
+      0
+    ],
+    "spriteSize": [
+      63,
+      22
+    ],
+    "spriteSourceSize": [
+      81,
+      22
+    ],
+    "textureRect": [
+      [
+        146,
+        840
+      ],
+      [
+        63,
+        22
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_34_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      5
+    ],
+    "spriteSize": [
+      29,
+      10
+    ],
+    "spriteSourceSize": [
+      35,
+      20
+    ],
+    "textureRect": [
+      [
+        4084,
+        975
+      ],
+      [
+        29,
+        10
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_35_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      102,
+      78
+    ],
+    "spriteSourceSize": [
+      102,
+      78
+    ],
+    "textureRect": [
+      [
+        145,
+        3118
+      ],
+      [
+        102,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "dart_35_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -8,
+      0
+    ],
+    "spriteSize": [
+      74,
+      58
+    ],
+    "spriteSourceSize": [
+      90,
+      58
+    ],
+    "textureRect": [
+      [
+        3678,
+        2184
+      ],
+      [
+        74,
+        58
+      ]
+    ],
+    "textureRotated": true
+  },
+  "dart_35_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      0
+    ],
+    "spriteSize": [
+      49,
+      12
+    ],
+    "spriteSourceSize": [
+      61,
+      12
+    ],
+    "textureRect": [
+      [
+        4083,
+        1230
+      ],
+      [
+        49,
+        12
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eAlphaBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      122
+    ],
+    "spriteSourceSize": [
+      140,
+      122
+    ],
+    "textureRect": [
+      [
+        1511,
+        1091
+      ],
+      [
+        140,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eAnimateBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      162,
+      122
+    ],
+    "spriteSourceSize": [
+      162,
+      122
+    ],
+    "textureRect": [
+      [
+        1195,
+        499
+      ],
+      [
+        162,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eBGEOff_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      136,
+      114
+    ],
+    "spriteSourceSize": [
+      136,
+      116
+    ],
+    "textureRect": [
+      [
+        1636,
+        1228
+      ],
+      [
+        136,
+        114
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eBGEOn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      136,
+      112
+    ],
+    "spriteSourceSize": [
+      136,
+      114
+    ],
+    "textureRect": [
+      [
+        2164,
+        1147
+      ],
+      [
+        136,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eCollisionBlock01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        3555,
+        2712
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eCollisionBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      196,
+      128
+    ],
+    "spriteSourceSize": [
+      196,
+      132
+    ],
+    "textureRect": [
+      [
+        3899,
+        472
+      ],
+      [
+        196,
+        128
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eCountBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      138,
+      126
+    ],
+    "spriteSourceSize": [
+      138,
+      128
+    ],
+    "textureRect": [
+      [
+        895,
+        409
+      ],
+      [
+        138,
+        126
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eCounterBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      174,
+      126
+    ],
+    "spriteSourceSize": [
+      174,
+      128
+    ],
+    "textureRect": [
+      [
+        1,
+        430
+      ],
+      [
+        174,
+        126
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eFollowComBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      158,
+      124
+    ],
+    "spriteSourceSize": [
+      158,
+      124
+    ],
+    "textureRect": [
+      [
+        2886,
+        1249
+      ],
+      [
+        158,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eFollowPComBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      22
+    ],
+    "spriteSize": [
+      170,
+      168
+    ],
+    "spriteSourceSize": [
+      170,
+      212
+    ],
+    "textureRect": [
+      [
+        1358,
+        508
+      ],
+      [
+        170,
+        168
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eGhostDBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -6
+    ],
+    "spriteSize": [
+      141,
+      86
+    ],
+    "spriteSourceSize": [
+      141,
+      98
+    ],
+    "textureRect": [
+      [
+        164,
+        1322
+      ],
+      [
+        141,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eGhostEBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -6
+    ],
+    "spriteSize": [
+      129,
+      86
+    ],
+    "spriteSourceSize": [
+      129,
+      98
+    ],
+    "textureRect": [
+      [
+        1594,
+        1649
+      ],
+      [
+        129,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eInstantCountBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      18
+    ],
+    "spriteSize": [
+      140,
+      160
+    ],
+    "spriteSourceSize": [
+      140,
+      196
+    ],
+    "textureRect": [
+      [
+        1197,
+        247
+      ],
+      [
+        140,
+        160
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eMoveComBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      114,
+      124
+    ],
+    "spriteSourceSize": [
+      114,
+      124
+    ],
+    "textureRect": [
+      [
+        1843,
+        1871
+      ],
+      [
+        114,
+        124
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eOnDeathBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      18
+    ],
+    "spriteSize": [
+      108,
+      160
+    ],
+    "spriteSourceSize": [
+      108,
+      196
+    ],
+    "textureRect": [
+      [
+        1694,
+        10
+      ],
+      [
+        108,
+        160
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_ePHideBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      90,
+      114
+    ],
+    "spriteSourceSize": [
+      90,
+      120
+    ],
+    "textureRect": [
+      [
+        524,
+        2284
+      ],
+      [
+        90,
+        114
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_ePShowBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      106,
+      114
+    ],
+    "spriteSourceSize": [
+      106,
+      120
+    ],
+    "textureRect": [
+      [
+        3981,
+        2695
+      ],
+      [
+        106,
+        114
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_ePickupBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      156,
+      130
+    ],
+    "spriteSourceSize": [
+      156,
+      134
+    ],
+    "textureRect": [
+      [
+        3742,
+        1228
+      ],
+      [
+        156,
+        130
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_ePulseBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      134,
+      122
+    ],
+    "spriteSourceSize": [
+      134,
+      122
+    ],
+    "textureRect": [
+      [
+        1932,
+        1199
+      ],
+      [
+        134,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eRotateComBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      152,
+      124
+    ],
+    "spriteSourceSize": [
+      152,
+      124
+    ],
+    "textureRect": [
+      [
+        3893,
+        1762
+      ],
+      [
+        152,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eShakeBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      8
+    ],
+    "spriteSize": [
+      140,
+      104
+    ],
+    "spriteSourceSize": [
+      140,
+      120
+    ],
+    "textureRect": [
+      [
+        1495,
+        1214
+      ],
+      [
+        140,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eSpawnBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      134,
+      122
+    ],
+    "spriteSourceSize": [
+      134,
+      122
+    ],
+    "textureRect": [
+      [
+        2164,
+        1260
+      ],
+      [
+        134,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eStartPosBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -2
+    ],
+    "spriteSize": [
+      144,
+      86
+    ],
+    "spriteSourceSize": [
+      144,
+      90
+    ],
+    "textureRect": [
+      [
+        317,
+        724
+      ],
+      [
+        144,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eStopMoverBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      138,
+      138
+    ],
+    "spriteSourceSize": [
+      138,
+      152
+    ],
+    "textureRect": [
+      [
+        1973,
+        788
+      ],
+      [
+        138,
+        138
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eTint3DLBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      84,
+      112
+    ],
+    "spriteSourceSize": [
+      84,
+      112
+    ],
+    "textureRect": [
+      [
+        157,
+        2829
+      ],
+      [
+        84,
+        112
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eTintBGBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      77,
+      112
+    ],
+    "spriteSourceSize": [
+      77,
+      112
+    ],
+    "textureRect": [
+      [
+        644,
+        1057
+      ],
+      [
+        77,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eTintCol01Btn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      82,
+      112
+    ],
+    "spriteSourceSize": [
+      82,
+      112
+    ],
+    "textureRect": [
+      [
+        1566,
+        2160
+      ],
+      [
+        82,
+        112
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eTintG2Btn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      154,
+      110
+    ],
+    "spriteSourceSize": [
+      154,
+      112
+    ],
+    "textureRect": [
+      [
+        3557,
+        1489
+      ],
+      [
+        154,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eTintGBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      112
+    ],
+    "textureRect": [
+      [
+        1116,
+        2561
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eTintLBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      100,
+      112
+    ],
+    "spriteSourceSize": [
+      100,
+      112
+    ],
+    "textureRect": [
+      [
+        3148,
+        1631
+      ],
+      [
+        100,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eTintObjBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      84,
+      112
+    ],
+    "spriteSourceSize": [
+      84,
+      112
+    ],
+    "textureRect": [
+      [
+        1,
+        2928
+      ],
+      [
+        84,
+        112
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eToggleBtn2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -18
+    ],
+    "spriteSize": [
+      84,
+      86
+    ],
+    "spriteSourceSize": [
+      84,
+      122
+    ],
+    "textureRect": [
+      [
+        2235,
+        2688
+      ],
+      [
+        84,
+        86
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eToggleBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      44
+    ],
+    "spriteSize": [
+      158,
+      32
+    ],
+    "spriteSourceSize": [
+      158,
+      120
+    ],
+    "textureRect": [
+      [
+        3249,
+        1454
+      ],
+      [
+        158,
+        32
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eTouchBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      138,
+      126
+    ],
+    "spriteSourceSize": [
+      138,
+      126
+    ],
+    "textureRect": [
+      [
+        2626,
+        1053
+      ],
+      [
+        138,
+        126
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eeFABtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      79,
+      80
+    ],
+    "spriteSourceSize": [
+      79,
+      80
+    ],
+    "textureRect": [
+      [
+        641,
+        1433
+      ],
+      [
+        79,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eeFALBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      73,
+      80
+    ],
+    "spriteSourceSize": [
+      79,
+      80
+    ],
+    "textureRect": [
+      [
+        3175,
+        793
+      ],
+      [
+        73,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eeFARBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      72,
+      80
+    ],
+    "spriteSourceSize": [
+      78,
+      80
+    ],
+    "textureRect": [
+      [
+        637,
+        2471
+      ],
+      [
+        72,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eeFBBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      65,
+      112
+    ],
+    "spriteSourceSize": [
+      65,
+      120
+    ],
+    "textureRect": [
+      [
+        1843,
+        2097
+      ],
+      [
+        65,
+        112
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eeFLBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      1
+    ],
+    "spriteSize": [
+      112,
+      64
+    ],
+    "spriteSourceSize": [
+      116,
+      66
+    ],
+    "textureRect": [
+      [
+        1679,
+        2235
+      ],
+      [
+        112,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eeFRBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      1
+    ],
+    "spriteSize": [
+      111,
+      64
+    ],
+    "spriteSourceSize": [
+      117,
+      66
+    ],
+    "textureRect": [
+      [
+        1329,
+        2412
+      ],
+      [
+        111,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eeFRHBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      116
+    ],
+    "spriteSourceSize": [
+      52,
+      116
+    ],
+    "textureRect": [
+      [
+        447,
+        1393
+      ],
+      [
+        52,
+        116
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eeFRHInvBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      118
+    ],
+    "spriteSourceSize": [
+      52,
+      118
+    ],
+    "textureRect": [
+      [
+        2111,
+        958
+      ],
+      [
+        52,
+        118
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eeFTBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      65,
+      112
+    ],
+    "spriteSourceSize": [
+      65,
+      112
+    ],
+    "textureRect": [
+      [
+        1843,
+        2163
+      ],
+      [
+        65,
+        112
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_eeNoneBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      104,
+      104
+    ],
+    "spriteSourceSize": [
+      104,
+      104
+    ],
+    "textureRect": [
+      [
+        3043,
+        2317
+      ],
+      [
+        104,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eeSDBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -8,
+      0
+    ],
+    "spriteSize": [
+      105,
+      48
+    ],
+    "spriteSourceSize": [
+      121,
+      50
+    ],
+    "textureRect": [
+      [
+        2518,
+        1804
+      ],
+      [
+        105,
+        48
+      ]
+    ],
+    "textureRotated": false
+  },
+  "edit_eeSUBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      0
+    ],
+    "spriteSize": [
+      108,
+      50
+    ],
+    "spriteSourceSize": [
+      116,
+      50
+    ],
+    "textureRect": [
+      [
+        1792,
+        2178
+      ],
+      [
+        108,
+        50
+      ]
+    ],
+    "textureRotated": true
+  },
+  "edit_scaleBtn_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      108,
+      60
+    ],
+    "spriteSourceSize": [
+      108,
+      60
+    ],
+    "textureRect": [
+      [
+        3672,
+        2869
+      ],
+      [
+        108,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "fireBoost_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      48,
+      64
+    ],
+    "spriteSourceSize": [
+      48,
+      64
+    ],
+    "textureRect": [
+      [
+        3966,
+        3107
+      ],
+      [
+        48,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "floorLine_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      1764,
+      6
+    ],
+    "spriteSourceSize": [
+      1776,
+      6
+    ],
+    "textureRect": [
+      [
+        1803,
+        1
+      ],
+      [
+        1764,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "floorLine_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      1801,
+      8
+    ],
+    "spriteSourceSize": [
+      1801,
+      8
+    ],
+    "textureRect": [
+      [
+        1,
+        1
+      ],
+      [
+        1801,
+        8
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_00_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3249,
+        1884
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_00_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      44,
+      44
+    ],
+    "spriteSourceSize": [
+      44,
+      44
+    ],
+    "textureRect": [
+      [
+        1307,
+        2930
+      ],
+      [
+        44,
+        44
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2872,
+        1996
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      26
+    ],
+    "spriteSourceSize": [
+      26,
+      26
+    ],
+    "textureRect": [
+      [
+        325,
+        478
+      ],
+      [
+        26,
+        26
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2746,
+        2018
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      78,
+      60
+    ],
+    "spriteSourceSize": [
+      78,
+      60
+    ],
+    "textureRect": [
+      [
+        2864,
+        2882
+      ],
+      [
+        78,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2623,
+        2020
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      23,
+      0
+    ],
+    "spriteSize": [
+      66,
+      112
+    ],
+    "spriteSourceSize": [
+      112,
+      112
+    ],
+    "textureRect": [
+      [
+        1443,
+        2226
+      ],
+      [
+        66,
+        112
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2498,
+        2096
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      73,
+      54
+    ],
+    "spriteSourceSize": [
+      73,
+      68
+    ],
+    "textureRect": [
+      [
+        2366,
+        2538
+      ],
+      [
+        73,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_05_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2868,
+        2117
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_05_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      27
+    ],
+    "spriteSize": [
+      66,
+      22
+    ],
+    "spriteSourceSize": [
+      66,
+      76
+    ],
+    "textureRect": [
+      [
+        148,
+        708
+      ],
+      [
+        66,
+        22
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_06_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2745,
+        2139
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_06_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      113,
+      112
+    ],
+    "spriteSourceSize": [
+      113,
+      112
+    ],
+    "textureRect": [
+      [
+        3785,
+        558
+      ],
+      [
+        113,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_07_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2620,
+        2141
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_07_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      12
+    ],
+    "spriteSize": [
+      18,
+      30
+    ],
+    "spriteSourceSize": [
+      18,
+      54
+    ],
+    "textureRect": [
+      [
+        1335,
+        978
+      ],
+      [
+        18,
+        30
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_08_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2353,
+        2146
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_08_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      113,
+      112
+    ],
+    "spriteSourceSize": [
+      113,
+      112
+    ],
+    "textureRect": [
+      [
+        3785,
+        671
+      ],
+      [
+        113,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_09_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2215,
+        2168
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_09_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      21
+    ],
+    "spriteSize": [
+      63,
+      22
+    ],
+    "spriteSourceSize": [
+      63,
+      64
+    ],
+    "textureRect": [
+      [
+        146,
+        904
+      ],
+      [
+        63,
+        22
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_100_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        3734,
+        2749
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_100_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -7
+    ],
+    "spriteSize": [
+      102,
+      66
+    ],
+    "spriteSourceSize": [
+      102,
+      80
+    ],
+    "textureRect": [
+      [
+        2061,
+        2568
+      ],
+      [
+        102,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_100_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -3
+    ],
+    "spriteSize": [
+      100,
+      72
+    ],
+    "spriteSourceSize": [
+      100,
+      78
+    ],
+    "textureRect": [
+      [
+        3148,
+        2192
+      ],
+      [
+        100,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_101_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        2864,
+        2359
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_101_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      104,
+      76
+    ],
+    "spriteSourceSize": [
+      104,
+      78
+    ],
+    "textureRect": [
+      [
+        938,
+        2815
+      ],
+      [
+        104,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_101_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      102,
+      74
+    ],
+    "spriteSourceSize": [
+      102,
+      76
+    ],
+    "textureRect": [
+      [
+        2440,
+        2459
+      ],
+      [
+        102,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_102_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        3855,
+        2855
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_102_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      108,
+      108
+    ],
+    "spriteSourceSize": [
+      108,
+      108
+    ],
+    "textureRect": [
+      [
+        2179,
+        2289
+      ],
+      [
+        108,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_102_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      18
+    ],
+    "spriteSize": [
+      82,
+      12
+    ],
+    "spriteSourceSize": [
+      84,
+      48
+    ],
+    "textureRect": [
+      [
+        2755,
+        506
+      ],
+      [
+        82,
+        12
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_103_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        2719,
+        2381
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_103_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -36
+    ],
+    "spriteSize": [
+      49,
+      20
+    ],
+    "spriteSourceSize": [
+      49,
+      92
+    ],
+    "textureRect": [
+      [
+        3720,
+        1236
+      ],
+      [
+        49,
+        20
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_103_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -4
+    ],
+    "spriteSize": [
+      102,
+      84
+    ],
+    "spriteSourceSize": [
+      102,
+      98
+    ],
+    "textureRect": [
+      [
+        819,
+        2910
+      ],
+      [
+        102,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_104_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        2581,
+        2383
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_104_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      13,
+      -5
+    ],
+    "spriteSize": [
+      47,
+      80
+    ],
+    "spriteSourceSize": [
+      73,
+      90
+    ],
+    "textureRect": [
+      [
+        637,
+        2544
+      ],
+      [
+        47,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_104_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      2
+    ],
+    "spriteSize": [
+      146,
+      96
+    ],
+    "spriteSourceSize": [
+      148,
+      100
+    ],
+    "textureRect": [
+      [
+        504,
+        613
+      ],
+      [
+        146,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_105_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -2
+    ],
+    "spriteSize": [
+      127,
+      126
+    ],
+    "spriteSourceSize": [
+      131,
+      130
+    ],
+    "textureRect": [
+      [
+        2626,
+        1321
+      ],
+      [
+        127,
+        126
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_105_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      117,
+      110
+    ],
+    "spriteSourceSize": [
+      123,
+      110
+    ],
+    "textureRect": [
+      [
+        1,
+        2817
+      ],
+      [
+        117,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_105_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      -10
+    ],
+    "spriteSize": [
+      99,
+      98
+    ],
+    "spriteSourceSize": [
+      113,
+      118
+    ],
+    "textureRect": [
+      [
+        3148,
+        2393
+      ],
+      [
+        99,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_106_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        2840,
+        2480
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_106_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        1328,
+        2477
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_106_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      108,
+      108
+    ],
+    "spriteSourceSize": [
+      108,
+      108
+    ],
+    "textureRect": [
+      [
+        2066,
+        2350
+      ],
+      [
+        108,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_107_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        2702,
+        2502
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_107_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      108,
+      108
+    ],
+    "spriteSourceSize": [
+      108,
+      108
+    ],
+    "textureRect": [
+      [
+        2179,
+        2289
+      ],
+      [
+        108,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_108_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      124
+    ],
+    "spriteSourceSize": [
+      120,
+      124
+    ],
+    "textureRect": [
+      [
+        2250,
+        1925
+      ],
+      [
+        120,
+        124
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_108_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -3
+    ],
+    "spriteSize": [
+      90,
+      66
+    ],
+    "spriteSourceSize": [
+      90,
+      72
+    ],
+    "textureRect": [
+      [
+        1945,
+        2655
+      ],
+      [
+        90,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_109_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      123,
+      120
+    ],
+    "spriteSourceSize": [
+      123,
+      120
+    ],
+    "textureRect": [
+      [
+        2106,
+        1934
+      ],
+      [
+        123,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_109_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -3
+    ],
+    "spriteSize": [
+      109,
+      104
+    ],
+    "spriteSourceSize": [
+      113,
+      110
+    ],
+    "textureRect": [
+      [
+        3043,
+        2207
+      ],
+      [
+        109,
+        104
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_109_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      26,
+      -22
+    ],
+    "spriteSize": [
+      59,
+      64
+    ],
+    "spriteSourceSize": [
+      111,
+      108
+    ],
+    "textureRect": [
+      [
+        3497,
+        1704
+      ],
+      [
+        59,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_10_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2475,
+        2217
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_10_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      18
+    ],
+    "spriteSize": [
+      85,
+      22
+    ],
+    "spriteSourceSize": [
+      85,
+      58
+    ],
+    "textureRect": [
+      [
+        1171,
+        643
+      ],
+      [
+        85,
+        22
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_110_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      127,
+      126
+    ],
+    "spriteSourceSize": [
+      127,
+      126
+    ],
+    "textureRect": [
+      [
+        2138,
+        1686
+      ],
+      [
+        127,
+        126
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_110_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2337,
+        2267
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_111_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      127,
+      128
+    ],
+    "spriteSourceSize": [
+      127,
+      128
+    ],
+    "textureRect": [
+      [
+        2625,
+        1449
+      ],
+      [
+        127,
+        128
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_111_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        2823,
+        2601
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_111_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -198.5,
+      198.5
+    ],
+    "spriteSize": [
+      3,
+      3
+    ],
+    "spriteSourceSize": [
+      400,
+      400
+    ],
+    "textureRect": [
+      [
+        3558,
+        108
+      ],
+      [
+        3,
+        3
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_112_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      122
+    ],
+    "spriteSourceSize": [
+      121,
+      122
+    ],
+    "textureRect": [
+      [
+        2230,
+        2046
+      ],
+      [
+        121,
+        122
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_112_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      115,
+      114
+    ],
+    "spriteSourceSize": [
+      115,
+      114
+    ],
+    "textureRect": [
+      [
+        3981,
+        2468
+      ],
+      [
+        115,
+        114
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_112_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      5
+    ],
+    "spriteSize": [
+      113,
+      100
+    ],
+    "spriteSourceSize": [
+      113,
+      110
+    ],
+    "textureRect": [
+      [
+        3148,
+        1517
+      ],
+      [
+        113,
+        100
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_113_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      141,
+      120
+    ],
+    "spriteSourceSize": [
+      143,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        1197
+      ],
+      [
+        141,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_113_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      0
+    ],
+    "spriteSize": [
+      135,
+      112
+    ],
+    "spriteSourceSize": [
+      139,
+      112
+    ],
+    "textureRect": [
+      [
+        1531,
+        312
+      ],
+      [
+        135,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_113_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      131,
+      110
+    ],
+    "spriteSourceSize": [
+      133,
+      110
+    ],
+    "textureRect": [
+      [
+        2436,
+        1281
+      ],
+      [
+        131,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_114_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      122,
+      122
+    ],
+    "spriteSourceSize": [
+      122,
+      122
+    ],
+    "textureRect": [
+      [
+        2875,
+        1873
+      ],
+      [
+        122,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_114_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      112,
+      112
+    ],
+    "spriteSourceSize": [
+      112,
+      112
+    ],
+    "textureRect": [
+      [
+        524,
+        2446
+      ],
+      [
+        112,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_114_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      14,
+      -26
+    ],
+    "spriteSize": [
+      81,
+      52
+    ],
+    "spriteSourceSize": [
+      109,
+      104
+    ],
+    "textureRect": [
+      [
+        2989,
+        2322
+      ],
+      [
+        81,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_115_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      124,
+      122
+    ],
+    "spriteSourceSize": [
+      124,
+      122
+    ],
+    "textureRect": [
+      [
+        2391,
+        1900
+      ],
+      [
+        124,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_115_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      118,
+      116
+    ],
+    "spriteSourceSize": [
+      118,
+      116
+    ],
+    "textureRect": [
+      [
+        1330,
+        2071
+      ],
+      [
+        118,
+        116
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_115_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -20
+    ],
+    "spriteSize": [
+      113,
+      70
+    ],
+    "spriteSourceSize": [
+      113,
+      110
+    ],
+    "textureRect": [
+      [
+        524,
+        2375
+      ],
+      [
+        113,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_116_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      133,
+      122
+    ],
+    "spriteSourceSize": [
+      133,
+      122
+    ],
+    "textureRect": [
+      [
+        2332,
+        836
+      ],
+      [
+        133,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_116_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      129,
+      118
+    ],
+    "spriteSourceSize": [
+      129,
+      118
+    ],
+    "textureRect": [
+      [
+        1330,
+        1712
+      ],
+      [
+        129,
+        118
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_116_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      127,
+      114
+    ],
+    "spriteSourceSize": [
+      127,
+      114
+    ],
+    "textureRect": [
+      [
+        1853,
+        1756
+      ],
+      [
+        127,
+        114
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_117_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        444,
+        1560
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_117_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      88,
+      110
+    ],
+    "spriteSourceSize": [
+      88,
+      110
+    ],
+    "textureRect": [
+      [
+        1,
+        3124
+      ],
+      [
+        88,
+        110
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_117_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      85,
+      108
+    ],
+    "spriteSourceSize": [
+      85,
+      108
+    ],
+    "textureRect": [
+      [
+        1244,
+        1853
+      ],
+      [
+        85,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_118_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        721,
+        1621
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_118_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      118,
+      118
+    ],
+    "spriteSourceSize": [
+      118,
+      118
+    ],
+    "textureRect": [
+      [
+        3976,
+        2905
+      ],
+      [
+        118,
+        118
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_118_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -15
+    ],
+    "spriteSize": [
+      108,
+      62
+    ],
+    "spriteSourceSize": [
+      108,
+      92
+    ],
+    "textureRect": [
+      [
+        3493,
+        2127
+      ],
+      [
+        108,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_119_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        302,
+        1640
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_119_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        951,
+        2593
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_119_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      108,
+      108
+    ],
+    "spriteSourceSize": [
+      108,
+      108
+    ],
+    "textureRect": [
+      [
+        1954,
+        2370
+      ],
+      [
+        108,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_11_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3739,
+        1781
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_11_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      9
+    ],
+    "spriteSize": [
+      71,
+      26
+    ],
+    "spriteSourceSize": [
+      71,
+      44
+    ],
+    "textureRect": [
+      [
+        3148,
+        657
+      ],
+      [
+        71,
+        26
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_120_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        161,
+        1691
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_120_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        831,
+        2611
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_121_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      134,
+      124
+    ],
+    "spriteSourceSize": [
+      134,
+      126
+    ],
+    "textureRect": [
+      [
+        2301,
+        1215
+      ],
+      [
+        134,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_121_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      122,
+      114
+    ],
+    "spriteSourceSize": [
+      122,
+      114
+    ],
+    "textureRect": [
+      [
+        1967,
+        2059
+      ],
+      [
+        122,
+        114
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_121_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      1
+    ],
+    "spriteSize": [
+      100,
+      84
+    ],
+    "spriteSourceSize": [
+      102,
+      86
+    ],
+    "textureRect": [
+      [
+        3148,
+        1947
+      ],
+      [
+        100,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_122_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      122,
+      122
+    ],
+    "spriteSourceSize": [
+      122,
+      122
+    ],
+    "textureRect": [
+      [
+        2749,
+        1895
+      ],
+      [
+        122,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_122_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      112,
+      110
+    ],
+    "spriteSourceSize": [
+      112,
+      110
+    ],
+    "textureRect": [
+      [
+        718,
+        2551
+      ],
+      [
+        112,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_123_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        423,
+        1681
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_123_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      0
+    ],
+    "spriteSize": [
+      99,
+      110
+    ],
+    "spriteSourceSize": [
+      109,
+      110
+    ],
+    "textureRect": [
+      [
+        3048,
+        1136
+      ],
+      [
+        99,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_124_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      124,
+      124
+    ],
+    "spriteSourceSize": [
+      124,
+      124
+    ],
+    "textureRect": [
+      [
+        2877,
+        1748
+      ],
+      [
+        124,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_124_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      118,
+      118
+    ],
+    "spriteSourceSize": [
+      118,
+      118
+    ],
+    "textureRect": [
+      [
+        1451,
+        2028
+      ],
+      [
+        118,
+        118
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_125_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        282,
+        1761
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_125_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      112,
+      112
+    ],
+    "spriteSourceSize": [
+      112,
+      112
+    ],
+    "textureRect": [
+      [
+        524,
+        2559
+      ],
+      [
+        112,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_126_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      136,
+      124
+    ],
+    "spriteSourceSize": [
+      136,
+      124
+    ],
+    "textureRect": [
+      [
+        1529,
+        627
+      ],
+      [
+        136,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_126_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      128,
+      102
+    ],
+    "spriteSourceSize": [
+      128,
+      114
+    ],
+    "textureRect": [
+      [
+        1724,
+        1655
+      ],
+      [
+        128,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_127_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      126,
+      120
+    ],
+    "spriteSourceSize": [
+      126,
+      120
+    ],
+    "textureRect": [
+      [
+        1589,
+        1839
+      ],
+      [
+        126,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_127_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      14
+    ],
+    "spriteSize": [
+      110,
+      78
+    ],
+    "spriteSourceSize": [
+      110,
+      106
+    ],
+    "textureRect": [
+      [
+        1843,
+        2340
+      ],
+      [
+        110,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_127_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -7
+    ],
+    "spriteSize": [
+      120,
+      68
+    ],
+    "spriteSourceSize": [
+      120,
+      82
+    ],
+    "textureRect": [
+      [
+        1,
+        2679
+      ],
+      [
+        120,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_128_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      124,
+      124
+    ],
+    "spriteSourceSize": [
+      124,
+      124
+    ],
+    "textureRect": [
+      [
+        2750,
+        1770
+      ],
+      [
+        124,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_128_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      116,
+      116
+    ],
+    "spriteSourceSize": [
+      116,
+      116
+    ],
+    "textureRect": [
+      [
+        3147,
+        2610
+      ],
+      [
+        116,
+        116
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_128_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      -4
+    ],
+    "spriteSize": [
+      84,
+      90
+    ],
+    "spriteSourceSize": [
+      88,
+      98
+    ],
+    "textureRect": [
+      [
+        2164,
+        2578
+      ],
+      [
+        84,
+        90
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_129_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        403,
+        1802
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_129_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      106,
+      106
+    ],
+    "spriteSourceSize": [
+      106,
+      106
+    ],
+    "textureRect": [
+      [
+        1548,
+        2611
+      ],
+      [
+        106,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_129_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      79,
+      80
+    ],
+    "spriteSourceSize": [
+      79,
+      80
+    ],
+    "textureRect": [
+      [
+        641,
+        1514
+      ],
+      [
+        79,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_12_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3557,
+        1921
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_12_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -4
+    ],
+    "spriteSize": [
+      85,
+      70
+    ],
+    "spriteSourceSize": [
+      85,
+      78
+    ],
+    "textureRect": [
+      [
+        1423,
+        2845
+      ],
+      [
+        85,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_130_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        842,
+        1686
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_130_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      112,
+      110
+    ],
+    "spriteSourceSize": [
+      112,
+      110
+    ],
+    "textureRect": [
+      [
+        520,
+        2672
+      ],
+      [
+        112,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_131_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        721,
+        1742
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_131_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      112,
+      112
+    ],
+    "spriteSourceSize": [
+      112,
+      112
+    ],
+    "textureRect": [
+      [
+        1330,
+        2188
+      ],
+      [
+        112,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_131_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      74,
+      74
+    ],
+    "spriteSourceSize": [
+      74,
+      74
+    ],
+    "textureRect": [
+      [
+        3189,
+        2844
+      ],
+      [
+        74,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_132_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        1711
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_132_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      104
+    ],
+    "spriteSourceSize": [
+      110,
+      104
+    ],
+    "textureRect": [
+      [
+        3043,
+        2096
+      ],
+      [
+        110,
+        104
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_133_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      122,
+      122
+    ],
+    "spriteSourceSize": [
+      122,
+      122
+    ],
+    "textureRect": [
+      [
+        2623,
+        1897
+      ],
+      [
+        122,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_133_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        716,
+        2662
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_133_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      20,
+      20
+    ],
+    "spriteSourceSize": [
+      20,
+      20
+    ],
+    "textureRect": [
+      [
+        143,
+        1233
+      ],
+      [
+        20,
+        20
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_134_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      122,
+      122
+    ],
+    "spriteSourceSize": [
+      122,
+      122
+    ],
+    "textureRect": [
+      [
+        2375,
+        2023
+      ],
+      [
+        122,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_134_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      116,
+      116
+    ],
+    "spriteSourceSize": [
+      116,
+      116
+    ],
+    "textureRect": [
+      [
+        3369,
+        2685
+      ],
+      [
+        116,
+        116
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_135_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      120,
+      126
+    ],
+    "spriteSourceSize": [
+      120,
+      130
+    ],
+    "textureRect": [
+      [
+        2402,
+        1654
+      ],
+      [
+        120,
+        126
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_135_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      112,
+      118
+    ],
+    "spriteSourceSize": [
+      112,
+      122
+    ],
+    "textureRect": [
+      [
+        3983,
+        1891
+      ],
+      [
+        112,
+        118
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_136_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        1832
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_136_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      116,
+      114
+    ],
+    "spriteSourceSize": [
+      116,
+      114
+    ],
+    "textureRect": [
+      [
+        3981,
+        2351
+      ],
+      [
+        116,
+        114
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_136_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      25,
+      -2
+    ],
+    "spriteSize": [
+      62,
+      60
+    ],
+    "spriteSourceSize": [
+      112,
+      64
+    ],
+    "textureRect": [
+      [
+        3671,
+        3050
+      ],
+      [
+        62,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_137_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      6
+    ],
+    "spriteSize": [
+      132,
+      134
+    ],
+    "spriteSourceSize": [
+      136,
+      146
+    ],
+    "textureRect": [
+      [
+        1668,
+        171
+      ],
+      [
+        132,
+        134
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_137_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      7
+    ],
+    "spriteSize": [
+      126,
+      128
+    ],
+    "spriteSourceSize": [
+      130,
+      142
+    ],
+    "textureRect": [
+      [
+        2626,
+        1192
+      ],
+      [
+        126,
+        128
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_137_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      27,
+      44
+    ],
+    "spriteSize": [
+      64,
+      54
+    ],
+    "spriteSourceSize": [
+      118,
+      142
+    ],
+    "textureRect": [
+      [
+        3732,
+        3099
+      ],
+      [
+        64,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_138_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        161,
+        1812
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_138_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      108,
+      108
+    ],
+    "spriteSourceSize": [
+      108,
+      108
+    ],
+    "textureRect": [
+      [
+        1843,
+        2419
+      ],
+      [
+        108,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_138_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      106,
+      106
+    ],
+    "spriteSourceSize": [
+      106,
+      106
+    ],
+    "textureRect": [
+      [
+        1435,
+        2651
+      ],
+      [
+        106,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_139_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        282,
+        1882
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_139_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        942,
+        2704
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_139_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      108,
+      108
+    ],
+    "spriteSourceSize": [
+      108,
+      108
+    ],
+    "textureRect": [
+      [
+        1665,
+        2490
+      ],
+      [
+        108,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_13_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3371,
+        1961
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_13_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      21
+    ],
+    "spriteSize": [
+      64,
+      22
+    ],
+    "spriteSourceSize": [
+      64,
+      64
+    ],
+    "textureRect": [
+      [
+        146,
+        775
+      ],
+      [
+        64,
+        22
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_140_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        403,
+        1923
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_140_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        827,
+        2722
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_141_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      124,
+      124
+    ],
+    "spriteSourceSize": [
+      124,
+      124
+    ],
+    "textureRect": [
+      [
+        2624,
+        1772
+      ],
+      [
+        124,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_141_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      116,
+      116
+    ],
+    "spriteSourceSize": [
+      116,
+      116
+    ],
+    "textureRect": [
+      [
+        3147,
+        2727
+      ],
+      [
+        116,
+        116
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_141_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      94,
+      94
+    ],
+    "spriteSourceSize": [
+      94,
+      94
+    ],
+    "textureRect": [
+      [
+        1114,
+        3009
+      ],
+      [
+        94,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_142_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        1953
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_142_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      92,
+      92
+    ],
+    "spriteSourceSize": [
+      92,
+      92
+    ],
+    "textureRect": [
+      [
+        912,
+        3059
+      ],
+      [
+        92,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_142_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      88,
+      90
+    ],
+    "spriteSourceSize": [
+      88,
+      90
+    ],
+    "textureRect": [
+      [
+        2275,
+        2538
+      ],
+      [
+        88,
+        90
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_14_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3249,
+        2005
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_14_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      83,
+      82
+    ],
+    "spriteSourceSize": [
+      83,
+      82
+    ],
+    "textureRect": [
+      [
+        2697,
+        2789
+      ],
+      [
+        83,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_15_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3371,
+        2082
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_15_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      111,
+      110
+    ],
+    "spriteSourceSize": [
+      111,
+      110
+    ],
+    "textureRect": [
+      [
+        1556,
+        2243
+      ],
+      [
+        111,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_16_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3249,
+        2126
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_16_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      82,
+      82
+    ],
+    "spriteSourceSize": [
+      82,
+      82
+    ],
+    "textureRect": [
+      [
+        2781,
+        2828
+      ],
+      [
+        82,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_17_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2867,
+        2238
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_17_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      111,
+      110
+    ],
+    "spriteSourceSize": [
+      111,
+      110
+    ],
+    "textureRect": [
+      [
+        1443,
+        2293
+      ],
+      [
+        111,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_18_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2742,
+        2260
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_18_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      111,
+      110
+    ],
+    "spriteSourceSize": [
+      111,
+      110
+    ],
+    "textureRect": [
+      [
+        1330,
+        2301
+      ],
+      [
+        111,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_19_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2597,
+        2262
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_19_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      85,
+      84
+    ],
+    "spriteSourceSize": [
+      85,
+      84
+    ],
+    "textureRect": [
+      [
+        1244,
+        2057
+      ],
+      [
+        85,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_20_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        2459,
+        2338
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_20_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      95,
+      94
+    ],
+    "spriteSourceSize": [
+      95,
+      94
+    ],
+    "textureRect": [
+      [
+        544,
+        1783
+      ],
+      [
+        95,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_21_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3861,
+        1887
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_21_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      111,
+      110
+    ],
+    "spriteSourceSize": [
+      111,
+      110
+    ],
+    "textureRect": [
+      [
+        1117,
+        2450
+      ],
+      [
+        111,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_22_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3739,
+        1902
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_22_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      97,
+      98
+    ],
+    "spriteSourceSize": [
+      97,
+      98
+    ],
+    "textureRect": [
+      [
+        2944,
+        2713
+      ],
+      [
+        97,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_23_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3861,
+        2008
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_23_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      111,
+      112
+    ],
+    "spriteSourceSize": [
+      111,
+      112
+    ],
+    "textureRect": [
+      [
+        838,
+        2499
+      ],
+      [
+        111,
+        112
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_24_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3556,
+        2042
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_24_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      68,
+      68
+    ],
+    "spriteSourceSize": [
+      68,
+      68
+    ],
+    "textureRect": [
+      [
+        1774,
+        2561
+      ],
+      [
+        68,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_25_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3371,
+        2203
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_25_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      -1
+    ],
+    "spriteSize": [
+      108,
+      108
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        2175,
+        2398
+      ],
+      [
+        108,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_26_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3249,
+        2247
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_26_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      113,
+      112
+    ],
+    "spriteSourceSize": [
+      113,
+      112
+    ],
+    "textureRect": [
+      [
+        3983,
+        2010
+      ],
+      [
+        113,
+        112
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_27_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3738,
+        2023
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_27_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      103,
+      102
+    ],
+    "spriteSourceSize": [
+      103,
+      102
+    ],
+    "textureRect": [
+      [
+        3044,
+        1752
+      ],
+      [
+        103,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_28_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3860,
+        2129
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_28_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        716,
+        2773
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_29_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3556,
+        2163
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_29_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      111,
+      110
+    ],
+    "spriteSourceSize": [
+      111,
+      110
+    ],
+    "textureRect": [
+      [
+        1956,
+        2174
+      ],
+      [
+        111,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_30_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3371,
+        2324
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_30_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      92,
+      92
+    ],
+    "spriteSourceSize": [
+      92,
+      92
+    ],
+    "textureRect": [
+      [
+        698,
+        3056
+      ],
+      [
+        92,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_31_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3249,
+        2368
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_31_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      62
+    ],
+    "spriteSourceSize": [
+      63,
+      62
+    ],
+    "textureRect": [
+      [
+        2561,
+        1450
+      ],
+      [
+        63,
+        62
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_32_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3737,
+        2144
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_32_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      78,
+      90
+    ],
+    "spriteSourceSize": [
+      78,
+      96
+    ],
+    "textureRect": [
+      [
+        2622,
+        2683
+      ],
+      [
+        78,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_33_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3556,
+        2284
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_33_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      111,
+      110
+    ],
+    "spriteSourceSize": [
+      111,
+      110
+    ],
+    "textureRect": [
+      [
+        1843,
+        2229
+      ],
+      [
+        111,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_34_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3859,
+        2250
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_34_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      95,
+      94
+    ],
+    "spriteSourceSize": [
+      95,
+      94
+    ],
+    "textureRect": [
+      [
+        1211,
+        2918
+      ],
+      [
+        95,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_35_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3737,
+        2265
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_35_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      111,
+      110
+    ],
+    "spriteSourceSize": [
+      111,
+      110
+    ],
+    "textureRect": [
+      [
+        1668,
+        2300
+      ],
+      [
+        111,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_36_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3859,
+        2371
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_36_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      65,
+      90
+    ],
+    "spriteSourceSize": [
+      65,
+      90
+    ],
+    "textureRect": [
+      [
+        2636,
+        2504
+      ],
+      [
+        65,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_37_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3737,
+        2386
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_37_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      111,
+      76
+    ],
+    "spriteSourceSize": [
+      111,
+      76
+    ],
+    "textureRect": [
+      [
+        1442,
+        2404
+      ],
+      [
+        111,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_38_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3859,
+        2492
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_38_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      98,
+      98
+    ],
+    "spriteSourceSize": [
+      98,
+      98
+    ],
+    "textureRect": [
+      [
+        1227,
+        2566
+      ],
+      [
+        98,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_39_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3556,
+        2405
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_39_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -7
+    ],
+    "spriteSize": [
+      76,
+      62
+    ],
+    "spriteSourceSize": [
+      76,
+      76
+    ],
+    "textureRect": [
+      [
+        3492,
+        2606
+      ],
+      [
+        76,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_40_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3737,
+        2507
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_40_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -2
+    ],
+    "spriteSize": [
+      62,
+      52
+    ],
+    "spriteSourceSize": [
+      62,
+      56
+    ],
+    "textureRect": [
+      [
+        3797,
+        3121
+      ],
+      [
+        62,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_41_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3859,
+        2613
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_41_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      83,
+      84
+    ],
+    "spriteSourceSize": [
+      83,
+      84
+    ],
+    "textureRect": [
+      [
+        2409,
+        2763
+      ],
+      [
+        83,
+        84
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_42_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3371,
+        2445
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_42_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      80,
+      82
+    ],
+    "spriteSourceSize": [
+      80,
+      84
+    ],
+    "textureRect": [
+      [
+        639,
+        2307
+      ],
+      [
+        80,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_43_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3556,
+        2526
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_43_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      -1
+    ],
+    "spriteSize": [
+      108,
+      108
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        2063,
+        2459
+      ],
+      [
+        108,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_44_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3737,
+        2628
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_44_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      23
+    ],
+    "spriteSize": [
+      66,
+      24
+    ],
+    "spriteSourceSize": [
+      66,
+      70
+    ],
+    "textureRect": [
+      [
+        3716,
+        1335
+      ],
+      [
+        66,
+        24
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_45_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3859,
+        2734
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_45_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -4
+    ],
+    "spriteSize": [
+      111,
+      102
+    ],
+    "spriteSourceSize": [
+      111,
+      110
+    ],
+    "textureRect": [
+      [
+        1555,
+        2354
+      ],
+      [
+        111,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_46_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      121,
+      120
+    ],
+    "spriteSourceSize": [
+      121,
+      120
+    ],
+    "textureRect": [
+      [
+        3248,
+        2489
+      ],
+      [
+        121,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_46_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      0
+    ],
+    "spriteSize": [
+      96,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        263,
+        3010
+      ],
+      [
+        96,
+        110
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_47_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        161,
+        1933
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_47_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      72,
+      72
+    ],
+    "spriteSourceSize": [
+      72,
+      72
+    ],
+    "textureRect": [
+      [
+        3339,
+        3009
+      ],
+      [
+        72,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_48_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        282,
+        2003
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_48_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      10
+    ],
+    "spriteSize": [
+      82,
+      48
+    ],
+    "spriteSourceSize": [
+      84,
+      68
+    ],
+    "textureRect": [
+      [
+        2662,
+        2872
+      ],
+      [
+        82,
+        48
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_49_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        2074
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_49_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -38
+    ],
+    "spriteSize": [
+      84,
+      34
+    ],
+    "spriteSourceSize": [
+      84,
+      110
+    ],
+    "textureRect": [
+      [
+        1159,
+        862
+      ],
+      [
+        84,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_50_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        161,
+        2054
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_50_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      62,
+      32
+    ],
+    "spriteSourceSize": [
+      62,
+      44
+    ],
+    "textureRect": [
+      [
+        3012,
+        1441
+      ],
+      [
+        62,
+        32
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_51_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      124,
+      120
+    ],
+    "spriteSourceSize": [
+      124,
+      120
+    ],
+    "textureRect": [
+      [
+        2125,
+        1813
+      ],
+      [
+        124,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_51_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      116,
+      96
+    ],
+    "spriteSourceSize": [
+      116,
+      96
+    ],
+    "textureRect": [
+      [
+        3555,
+        2833
+      ],
+      [
+        116,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_52_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      128,
+      120
+    ],
+    "spriteSourceSize": [
+      128,
+      120
+    ],
+    "textureRect": [
+      [
+        2043,
+        1353
+      ],
+      [
+        128,
+        120
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_52_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      98,
+      92
+    ],
+    "spriteSourceSize": [
+      98,
+      94
+    ],
+    "textureRect": [
+      [
+        1542,
+        2718
+      ],
+      [
+        98,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_53_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        2195
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_53_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      86,
+      80
+    ],
+    "spriteSourceSize": [
+      86,
+      84
+    ],
+    "textureRect": [
+      [
+        640,
+        2220
+      ],
+      [
+        86,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_54_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        963,
+        1687
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_54_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -20
+    ],
+    "spriteSize": [
+      102,
+      70
+    ],
+    "spriteSourceSize": [
+      102,
+      110
+    ],
+    "textureRect": [
+      [
+        2172,
+        2507
+      ],
+      [
+        102,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_55_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        842,
+        1807
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_55_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -10,
+      10
+    ],
+    "spriteSize": [
+      90,
+      90
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        2701,
+        2623
+      ],
+      [
+        90,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_56_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        721,
+        1863
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_56_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      78,
+      18
+    ],
+    "spriteSourceSize": [
+      78,
+      22
+    ],
+    "textureRect": [
+      [
+        142,
+        1473
+      ],
+      [
+        78,
+        18
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_57_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        403,
+        2044
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_57_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -17
+    ],
+    "spriteSize": [
+      92,
+      60
+    ],
+    "spriteSourceSize": [
+      92,
+      94
+    ],
+    "textureRect": [
+      [
+        2533,
+        2581
+      ],
+      [
+        92,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_58_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        282,
+        2124
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_58_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -4
+    ],
+    "spriteSize": [
+      94,
+      86
+    ],
+    "spriteSourceSize": [
+      94,
+      94
+    ],
+    "textureRect": [
+      [
+        1017,
+        3035
+      ],
+      [
+        94,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_59_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        161,
+        2175
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_59_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -19
+    ],
+    "spriteSize": [
+      98,
+      62
+    ],
+    "spriteSourceSize": [
+      98,
+      100
+    ],
+    "textureRect": [
+      [
+        3493,
+        2236
+      ],
+      [
+        98,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_60_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1123,
+        1743
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_60_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      88,
+      90
+    ],
+    "spriteSourceSize": [
+      88,
+      92
+    ],
+    "textureRect": [
+      [
+        2440,
+        2607
+      ],
+      [
+        88,
+        90
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_61_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        963,
+        1808
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_61_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -7
+    ],
+    "spriteSize": [
+      88,
+      64
+    ],
+    "spriteSourceSize": [
+      88,
+      78
+    ],
+    "textureRect": [
+      [
+        2523,
+        2731
+      ],
+      [
+        88,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_62_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      122,
+      120
+    ],
+    "spriteSourceSize": [
+      122,
+      120
+    ],
+    "textureRect": [
+      [
+        2092,
+        2055
+      ],
+      [
+        122,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_62_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      9
+    ],
+    "spriteSize": [
+      86,
+      18
+    ],
+    "spriteSourceSize": [
+      88,
+      36
+    ],
+    "textureRect": [
+      [
+        143,
+        1386
+      ],
+      [
+        86,
+        18
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_63_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        842,
+        1928
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_63_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      78,
+      70
+    ],
+    "spriteSourceSize": [
+      78,
+      70
+    ],
+    "textureRect": [
+      [
+        3027,
+        2862
+      ],
+      [
+        78,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_64_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        721,
+        1984
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_64_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      78,
+      78
+    ],
+    "spriteSourceSize": [
+      78,
+      78
+    ],
+    "textureRect": [
+      [
+        3110,
+        2844
+      ],
+      [
+        78,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_65_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        403,
+        2165
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_65_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -12
+    ],
+    "spriteSize": [
+      110,
+      86
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        2068,
+        2176
+      ],
+      [
+        110,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_66_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        282,
+        2245
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_66_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -28,
+      18
+    ],
+    "spriteSize": [
+      22,
+      22
+    ],
+    "spriteSourceSize": [
+      78,
+      58
+    ],
+    "textureRect": [
+      [
+        143,
+        1126
+      ],
+      [
+        22,
+        22
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_67_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        161,
+        2296
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_67_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      78,
+      66
+    ],
+    "spriteSourceSize": [
+      78,
+      66
+    ],
+    "textureRect": [
+      [
+        2944,
+        2867
+      ],
+      [
+        78,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_68_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      144,
+      120
+    ],
+    "spriteSourceSize": [
+      144,
+      120
+    ],
+    "textureRect": [
+      [
+        2632,
+        908
+      ],
+      [
+        144,
+        120
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_68_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -13
+    ],
+    "spriteSize": [
+      136,
+      84
+    ],
+    "spriteSourceSize": [
+      136,
+      110
+    ],
+    "textureRect": [
+      [
+        1003,
+        1430
+      ],
+      [
+        136,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_69_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        2316
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_69_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -6
+    ],
+    "spriteSize": [
+      110,
+      98
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        1230,
+        2344
+      ],
+      [
+        110,
+        98
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_70_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        2437
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_70_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      86,
+      88
+    ],
+    "spriteSourceSize": [
+      86,
+      90
+    ],
+    "textureRect": [
+      [
+        2345,
+        2642
+      ],
+      [
+        86,
+        88
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_71_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1123,
+        1864
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_71_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        510,
+        2783
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_72_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        963,
+        1929
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_72_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      70,
+      68
+    ],
+    "spriteSourceSize": [
+      70,
+      68
+    ],
+    "textureRect": [
+      [
+        3486,
+        2853
+      ],
+      [
+        70,
+        68
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_73_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        842,
+        2049
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_73_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      91,
+      94
+    ],
+    "spriteSourceSize": [
+      91,
+      94
+    ],
+    "textureRect": [
+      [
+        922,
+        2967
+      ],
+      [
+        91,
+        94
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_74_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      126,
+      120
+    ],
+    "spriteSourceSize": [
+      126,
+      120
+    ],
+    "textureRect": [
+      [
+        1459,
+        1852
+      ],
+      [
+        126,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_74_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      118,
+      92
+    ],
+    "spriteSourceSize": [
+      118,
+      94
+    ],
+    "textureRect": [
+      [
+        963,
+        2387
+      ],
+      [
+        118,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_75_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        721,
+        2105
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_75_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      30
+    ],
+    "spriteSize": [
+      25,
+      26
+    ],
+    "spriteSourceSize": [
+      27,
+      86
+    ],
+    "textureRect": [
+      [
+        1668,
+        139
+      ],
+      [
+        25,
+        26
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_76_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        403,
+        2286
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_76_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      80,
+      80
+    ],
+    "spriteSourceSize": [
+      80,
+      80
+    ],
+    "textureRect": [
+      [
+        638,
+        2390
+      ],
+      [
+        80,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_77_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        282,
+        2366
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_77_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      98,
+      98
+    ],
+    "spriteSourceSize": [
+      98,
+      98
+    ],
+    "textureRect": [
+      [
+        1227,
+        2665
+      ],
+      [
+        98,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_78_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        161,
+        2417
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_78_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -12
+    ],
+    "spriteSize": [
+      110,
+      86
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        2068,
+        2263
+      ],
+      [
+        110,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_79_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1330,
+        1950
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_79_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      76,
+      76
+    ],
+    "spriteSourceSize": [
+      76,
+      76
+    ],
+    "textureRect": [
+      [
+        3023,
+        2933
+      ],
+      [
+        76,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_80_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      126,
+      120
+    ],
+    "spriteSourceSize": [
+      126,
+      120
+    ],
+    "textureRect": [
+      [
+        1716,
+        1869
+      ],
+      [
+        126,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_80_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      118,
+      104
+    ],
+    "spriteSourceSize": [
+      118,
+      110
+    ],
+    "textureRect": [
+      [
+        3043,
+        1977
+      ],
+      [
+        118,
+        104
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_81_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1123,
+        1985
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_81_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      12
+    ],
+    "spriteSize": [
+      50,
+      52
+    ],
+    "spriteSourceSize": [
+      50,
+      76
+    ],
+    "textureRect": [
+      [
+        3796,
+        3184
+      ],
+      [
+        50,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_82_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        963,
+        2050
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_82_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      22,
+      22
+    ],
+    "spriteSourceSize": [
+      22,
+      22
+    ],
+    "textureRect": [
+      [
+        143,
+        1149
+      ],
+      [
+        22,
+        22
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_83_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        842,
+        2170
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_83_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      92,
+      92
+    ],
+    "spriteSourceSize": [
+      92,
+      92
+    ],
+    "textureRect": [
+      [
+        791,
+        3082
+      ],
+      [
+        92,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_84_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        721,
+        2226
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_84_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      22,
+      22
+    ],
+    "spriteSourceSize": [
+      22,
+      22
+    ],
+    "textureRect": [
+      [
+        143,
+        1172
+      ],
+      [
+        22,
+        22
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_85_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        403,
+        2407
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_85_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        389,
+        2839
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_86_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        282,
+        2487
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_86_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      108,
+      26
+    ],
+    "spriteSourceSize": [
+      108,
+      26
+    ],
+    "textureRect": [
+      [
+        1331,
+        138
+      ],
+      [
+        108,
+        26
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_87_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        159,
+        2538
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_87_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        270,
+        2899
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_88_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        2558
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_88_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        152,
+        2914
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_89_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        1119,
+        2106
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_89_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      108,
+      108
+    ],
+    "spriteSourceSize": [
+      108,
+      108
+    ],
+    "textureRect": [
+      [
+        1952,
+        2479
+      ],
+      [
+        108,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_90_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      120,
+      124
+    ],
+    "spriteSourceSize": [
+      120,
+      126
+    ],
+    "textureRect": [
+      [
+        1981,
+        1823
+      ],
+      [
+        120,
+        124
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_90_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      82,
+      108
+    ],
+    "spriteSourceSize": [
+      82,
+      120
+    ],
+    "textureRect": [
+      [
+        633,
+        2705
+      ],
+      [
+        82,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_91_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        963,
+        2171
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_91_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      27
+    ],
+    "spriteSize": [
+      86,
+      16
+    ],
+    "spriteSourceSize": [
+      86,
+      70
+    ],
+    "textureRect": [
+      [
+        3432,
+        997
+      ],
+      [
+        86,
+        16
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_92_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      152,
+      138
+    ],
+    "spriteSourceSize": [
+      152,
+      152
+    ],
+    "textureRect": [
+      [
+        1973,
+        635
+      ],
+      [
+        152,
+        138
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_92_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      13
+    ],
+    "spriteSize": [
+      144,
+      118
+    ],
+    "spriteSourceSize": [
+      144,
+      144
+    ],
+    "textureRect": [
+      [
+        2635,
+        619
+      ],
+      [
+        144,
+        118
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_93_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      142,
+      120
+    ],
+    "spriteSourceSize": [
+      142,
+      120
+    ],
+    "textureRect": [
+      [
+        314,
+        896
+      ],
+      [
+        142,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_93_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      5
+    ],
+    "spriteSize": [
+      132,
+      98
+    ],
+    "spriteSourceSize": [
+      132,
+      108
+    ],
+    "textureRect": [
+      [
+        1128,
+        1585
+      ],
+      [
+        132,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_94_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      142,
+      120
+    ],
+    "spriteSourceSize": [
+      142,
+      120
+    ],
+    "textureRect": [
+      [
+        169,
+        919
+      ],
+      [
+        142,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_94_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      17
+    ],
+    "spriteSize": [
+      132,
+      32
+    ],
+    "spriteSourceSize": [
+      132,
+      66
+    ],
+    "textureRect": [
+      [
+        1161,
+        729
+      ],
+      [
+        132,
+        32
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_95_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        842,
+        2291
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_95_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      76,
+      62
+    ],
+    "spriteSourceSize": [
+      76,
+      62
+    ],
+    "textureRect": [
+      [
+        3492,
+        2683
+      ],
+      [
+        76,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_96_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        720,
+        2347
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_96_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      9,
+      0
+    ],
+    "spriteSize": [
+      91,
+      110
+    ],
+    "spriteSourceSize": [
+      109,
+      110
+    ],
+    "textureRect": [
+      [
+        1238,
+        2233
+      ],
+      [
+        91,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_97_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -4
+    ],
+    "spriteSize": [
+      140,
+      130
+    ],
+    "spriteSourceSize": [
+      140,
+      138
+    ],
+    "textureRect": [
+      [
+        1654,
+        984
+      ],
+      [
+        140,
+        130
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_97_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -23
+    ],
+    "spriteSize": [
+      134,
+      88
+    ],
+    "spriteSourceSize": [
+      134,
+      134
+    ],
+    "textureRect": [
+      [
+        1469,
+        1428
+      ],
+      [
+        134,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_97_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -11
+    ],
+    "spriteSize": [
+      98,
+      86
+    ],
+    "spriteSourceSize": [
+      98,
+      108
+    ],
+    "textureRect": [
+      [
+        1433,
+        2758
+      ],
+      [
+        98,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_98_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      120
+    ],
+    "spriteSourceSize": [
+      120,
+      120
+    ],
+    "textureRect": [
+      [
+        403,
+        2528
+      ],
+      [
+        120,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_98_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      -18
+    ],
+    "spriteSize": [
+      84,
+      74
+    ],
+    "spriteSourceSize": [
+      86,
+      110
+    ],
+    "textureRect": [
+      [
+        2701,
+        2714
+      ],
+      [
+        84,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_98_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      -18
+    ],
+    "spriteSize": [
+      82,
+      72
+    ],
+    "spriteSourceSize": [
+      84,
+      108
+    ],
+    "textureRect": [
+      [
+        2871,
+        2722
+      ],
+      [
+        82,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_99_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      136,
+      124
+    ],
+    "spriteSourceSize": [
+      136,
+      124
+    ],
+    "textureRect": [
+      [
+        2328,
+        959
+      ],
+      [
+        136,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_99_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -19
+    ],
+    "spriteSize": [
+      102,
+      74
+    ],
+    "spriteSourceSize": [
+      102,
+      112
+    ],
+    "textureRect": [
+      [
+        2284,
+        2463
+      ],
+      [
+        102,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_99_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -16
+    ],
+    "spriteSize": [
+      100,
+      78
+    ],
+    "spriteSourceSize": [
+      100,
+      110
+    ],
+    "textureRect": [
+      [
+        3148,
+        2113
+      ],
+      [
+        100,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_00_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        1,
+        1056
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_00_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      58,
+      58
+    ],
+    "spriteSourceSize": [
+      58,
+      58
+    ],
+    "textureRect": [
+      [
+        3678,
+        2464
+      ],
+      [
+        58,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        167,
+        1040
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      72,
+      72
+    ],
+    "spriteSourceSize": [
+      72,
+      72
+    ],
+    "textureRect": [
+      [
+        3555,
+        2981
+      ],
+      [
+        72,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        1194,
+        794
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      -21
+    ],
+    "spriteSize": [
+      123,
+      90
+    ],
+    "spriteSourceSize": [
+      131,
+      132
+    ],
+    "textureRect": [
+      [
+        1713,
+        1990
+      ],
+      [
+        123,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        1010,
+        914
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      113,
+      112
+    ],
+    "spriteSourceSize": [
+      113,
+      112
+    ],
+    "textureRect": [
+      [
+        3983,
+        2124
+      ],
+      [
+        113,
+        112
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        865,
+        917
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      113,
+      112
+    ],
+    "spriteSourceSize": [
+      113,
+      112
+    ],
+    "textureRect": [
+      [
+        3982,
+        2238
+      ],
+      [
+        113,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_05_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        722,
+        924
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_05_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      89,
+      90
+    ],
+    "spriteSourceSize": [
+      89,
+      90
+    ],
+    "textureRect": [
+      [
+        1240,
+        2142
+      ],
+      [
+        89,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_06_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        502,
+        996
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_06_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      131,
+      132
+    ],
+    "spriteSourceSize": [
+      131,
+      132
+    ],
+    "textureRect": [
+      [
+        2334,
+        590
+      ],
+      [
+        131,
+        132
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_07_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        309,
+        1102
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_07_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      95,
+      96
+    ],
+    "spriteSourceSize": [
+      95,
+      96
+    ],
+    "textureRect": [
+      [
+        3052,
+        1039
+      ],
+      [
+        95,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_08_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        502,
+        1137
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_08_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      4
+    ],
+    "spriteSize": [
+      127,
+      124
+    ],
+    "spriteSourceSize": [
+      131,
+      132
+    ],
+    "textureRect": [
+      [
+        1997,
+        1698
+      ],
+      [
+        127,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_09_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      141,
+      140
+    ],
+    "spriteSourceSize": [
+      141,
+      140
+    ],
+    "textureRect": [
+      [
+        166,
+        1181
+      ],
+      [
+        141,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_09_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      19
+    ],
+    "spriteSize": [
+      53,
+      94
+    ],
+    "spriteSourceSize": [
+      53,
+      132
+    ],
+    "textureRect": [
+      [
+        2112,
+        183
+      ],
+      [
+        53,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_10_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1,
+        1429
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_10_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      101,
+      100
+    ],
+    "spriteSourceSize": [
+      101,
+      100
+    ],
+    "textureRect": [
+      [
+        3148,
+        1744
+      ],
+      [
+        101,
+        100
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_11_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        306,
+        1358
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_11_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      19,
+      -4
+    ],
+    "spriteSize": [
+      94,
+      124
+    ],
+    "spriteSourceSize": [
+      132,
+      132
+    ],
+    "textureRect": [
+      [
+        2529,
+        1679
+      ],
+      [
+        94,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_12_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        162,
+        1409
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_12_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      132,
+      132
+    ],
+    "spriteSourceSize": [
+      132,
+      132
+    ],
+    "textureRect": [
+      [
+        1880,
+        1421
+      ],
+      [
+        132,
+        132
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_13_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1357,
+        796
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_13_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      96,
+      132
+    ],
+    "spriteSourceSize": [
+      96,
+      132
+    ],
+    "textureRect": [
+      [
+        2067,
+        1220
+      ],
+      [
+        96,
+        132
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_14_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1194,
+        935
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_14_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      112,
+      132
+    ],
+    "spriteSourceSize": [
+      112,
+      132
+    ],
+    "textureRect": [
+      [
+        1330,
+        1518
+      ],
+      [
+        112,
+        132
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_15_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      142,
+      142
+    ],
+    "spriteSourceSize": [
+      142,
+      142
+    ],
+    "textureRect": [
+      [
+        1829,
+        793
+      ],
+      [
+        142,
+        142
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_15_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      112,
+      112
+    ],
+    "spriteSourceSize": [
+      112,
+      112
+    ],
+    "textureRect": [
+      [
+        1117,
+        2337
+      ],
+      [
+        112,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_16_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      132,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        2754,
+        755
+      ],
+      [
+        132,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_16_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -3
+    ],
+    "spriteSize": [
+      112,
+      106
+    ],
+    "spriteSourceSize": [
+      112,
+      112
+    ],
+    "textureRect": [
+      [
+        397,
+        2732
+      ],
+      [
+        112,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_17_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      132,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        2753,
+        1223
+      ],
+      [
+        132,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_17_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      9,
+      0
+    ],
+    "spriteSize": [
+      72,
+      76
+    ],
+    "spriteSourceSize": [
+      90,
+      76
+    ],
+    "textureRect": [
+      [
+        2871,
+        2805
+      ],
+      [
+        72,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_18_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1007,
+        1055
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_18_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      128,
+      128
+    ],
+    "spriteSourceSize": [
+      128,
+      128
+    ],
+    "textureRect": [
+      [
+        1460,
+        1723
+      ],
+      [
+        128,
+        128
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_19_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        864,
+        1058
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_19_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      130,
+      130
+    ],
+    "spriteSourceSize": [
+      130,
+      130
+    ],
+    "textureRect": [
+      [
+        2299,
+        1340
+      ],
+      [
+        130,
+        130
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_20_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        722,
+        1065
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_20_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      130,
+      130
+    ],
+    "spriteSourceSize": [
+      130,
+      130
+    ],
+    "textureRect": [
+      [
+        2164,
+        1383
+      ],
+      [
+        130,
+        130
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_21_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        501,
+        1278
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_21_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      36,
+      130
+    ],
+    "spriteSourceSize": [
+      36,
+      130
+    ],
+    "textureRect": [
+      [
+        467,
+        668
+      ],
+      [
+        36,
+        130
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_22_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        303,
+        1499
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_22_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      130,
+      130
+    ],
+    "spriteSourceSize": [
+      130,
+      130
+    ],
+    "textureRect": [
+      [
+        2430,
+        1392
+      ],
+      [
+        130,
+        130
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_22_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      76,
+      76
+    ],
+    "spriteSourceSize": [
+      76,
+      76
+    ],
+    "textureRect": [
+      [
+        2943,
+        2934
+      ],
+      [
+        76,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_23_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        161,
+        1550
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_23_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      85,
+      62
+    ],
+    "spriteSourceSize": [
+      87,
+      62
+    ],
+    "textureRect": [
+      [
+        3456,
+        738
+      ],
+      [
+        85,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_23_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      17
+    ],
+    "spriteSize": [
+      118,
+      94
+    ],
+    "spriteSourceSize": [
+      124,
+      128
+    ],
+    "textureRect": [
+      [
+        963,
+        2292
+      ],
+      [
+        118,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_24_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1,
+        1570
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_24_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      130,
+      130
+    ],
+    "spriteSourceSize": [
+      130,
+      130
+    ],
+    "textureRect": [
+      [
+        2295,
+        1471
+      ],
+      [
+        130,
+        130
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_24_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      90,
+      64
+    ],
+    "spriteSourceSize": [
+      90,
+      64
+    ],
+    "textureRect": [
+      [
+        1842,
+        2684
+      ],
+      [
+        90,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_25_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1517,
+        809
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_25_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      130,
+      130
+    ],
+    "spriteSourceSize": [
+      130,
+      130
+    ],
+    "textureRect": [
+      [
+        2426,
+        1523
+      ],
+      [
+        130,
+        130
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_25_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      88,
+      90
+    ],
+    "spriteSourceSize": [
+      88,
+      90
+    ],
+    "textureRect": [
+      [
+        2531,
+        2642
+      ],
+      [
+        88,
+        90
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_26_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1355,
+        937
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_26_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      -4
+    ],
+    "spriteSize": [
+      124,
+      124
+    ],
+    "spriteSourceSize": [
+      132,
+      132
+    ],
+    "textureRect": [
+      [
+        2393,
+        1775
+      ],
+      [
+        124,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_27_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1193,
+        1076
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_27_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      71,
+      84
+    ],
+    "spriteSourceSize": [
+      71,
+      92
+    ],
+    "textureRect": [
+      [
+        2612,
+        2774
+      ],
+      [
+        71,
+        84
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_28_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1005,
+        1196
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_28_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      130,
+      96
+    ],
+    "spriteSourceSize": [
+      130,
+      110
+    ],
+    "textureRect": [
+      [
+        1878,
+        1554
+      ],
+      [
+        130,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_28_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -11
+    ],
+    "spriteSize": [
+      46,
+      50
+    ],
+    "spriteSourceSize": [
+      46,
+      72
+    ],
+    "textureRect": [
+      [
+        1570,
+        2890
+      ],
+      [
+        46,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_29_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        863,
+        1199
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_29_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      132,
+      132
+    ],
+    "spriteSourceSize": [
+      132,
+      132
+    ],
+    "textureRect": [
+      [
+        1745,
+        1425
+      ],
+      [
+        132,
+        132
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_30_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        721,
+        1206
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_30_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      100,
+      100
+    ],
+    "spriteSourceSize": [
+      100,
+      100
+    ],
+    "textureRect": [
+      [
+        3148,
+        1846
+      ],
+      [
+        100,
+        100
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_31_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      138,
+      138
+    ],
+    "spriteSourceSize": [
+      138,
+      138
+    ],
+    "textureRect": [
+      [
+        1972,
+        927
+      ],
+      [
+        138,
+        138
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_31_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        1,
+        3013
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_32_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        500,
+        1419
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_32_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      124,
+      124
+    ],
+    "spriteSourceSize": [
+      124,
+      124
+    ],
+    "textureRect": [
+      [
+        2266,
+        1800
+      ],
+      [
+        124,
+        124
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_33_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -4
+    ],
+    "spriteSize": [
+      140,
+      132
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1955,
+        1066
+      ],
+      [
+        140,
+        132
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_33_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -5
+    ],
+    "spriteSize": [
+      132,
+      122
+    ],
+    "spriteSourceSize": [
+      132,
+      132
+    ],
+    "textureRect": [
+      [
+        1465,
+        1517
+      ],
+      [
+        132,
+        122
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_34_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      142,
+      142
+    ],
+    "spriteSourceSize": [
+      142,
+      142
+    ],
+    "textureRect": [
+      [
+        1016,
+        771
+      ],
+      [
+        142,
+        142
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_34_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      106,
+      132
+    ],
+    "spriteSourceSize": [
+      106,
+      132
+    ],
+    "textureRect": [
+      [
+        995,
+        1515
+      ],
+      [
+        106,
+        132
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_35_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      142,
+      141
+    ],
+    "spriteSourceSize": [
+      142,
+      141
+    ],
+    "textureRect": [
+      [
+        867,
+        775
+      ],
+      [
+        142,
+        141
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_35_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      112,
+      112
+    ],
+    "spriteSourceSize": [
+      112,
+      112
+    ],
+    "textureRect": [
+      [
+        960,
+        2480
+      ],
+      [
+        112,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_35_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      30,
+      19
+    ],
+    "spriteSourceSize": [
+      30,
+      19
+    ],
+    "textureRect": [
+      [
+        143,
+        1355
+      ],
+      [
+        30,
+        19
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_36_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1658,
+        843
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_36_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      98,
+      97
+    ],
+    "spriteSourceSize": [
+      98,
+      97
+    ],
+    "textureRect": [
+      [
+        1655,
+        2672
+      ],
+      [
+        98,
+        97
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_37_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1513,
+        950
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_37_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      116,
+      115
+    ],
+    "spriteSourceSize": [
+      116,
+      115
+    ],
+    "textureRect": [
+      [
+        524,
+        1995
+      ],
+      [
+        116,
+        115
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_38_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      144,
+      144
+    ],
+    "spriteSourceSize": [
+      144,
+      144
+    ],
+    "textureRect": [
+      [
+        504,
+        710
+      ],
+      [
+        144,
+        144
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_38_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      110,
+      110
+    ],
+    "spriteSourceSize": [
+      110,
+      110
+    ],
+    "textureRect": [
+      [
+        500,
+        2894
+      ],
+      [
+        110,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_39_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      142,
+      140
+    ],
+    "spriteSourceSize": [
+      142,
+      140
+    ],
+    "textureRect": [
+      [
+        722,
+        783
+      ],
+      [
+        142,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_39_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      94,
+      126
+    ],
+    "spriteSourceSize": [
+      94,
+      126
+    ],
+    "textureRect": [
+      [
+        2885,
+        1473
+      ],
+      [
+        94,
+        126
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_40_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      144,
+      144
+    ],
+    "spriteSourceSize": [
+      144,
+      144
+    ],
+    "textureRect": [
+      [
+        172,
+        691
+      ],
+      [
+        144,
+        144
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_40_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      132,
+      58
+    ],
+    "spriteSourceSize": [
+      132,
+      58
+    ],
+    "textureRect": [
+      [
+        1124,
+        1684
+      ],
+      [
+        132,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_41_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1354,
+        1078
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_41_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      104,
+      104
+    ],
+    "spriteSourceSize": [
+      104,
+      104
+    ],
+    "textureRect": [
+      [
+        3042,
+        2422
+      ],
+      [
+        104,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_42_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      0
+    ],
+    "spriteSize": [
+      131,
+      140
+    ],
+    "spriteSourceSize": [
+      139,
+      140
+    ],
+    "textureRect": [
+      [
+        2755,
+        614
+      ],
+      [
+        131,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_42_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      0
+    ],
+    "spriteSize": [
+      123,
+      132
+    ],
+    "spriteSourceSize": [
+      131,
+      132
+    ],
+    "textureRect": [
+      [
+        1604,
+        1436
+      ],
+      [
+        123,
+        132
+      ]
+    ],
+    "textureRotated": true
+  },
+  "player_ball_43_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      140,
+      140
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1814,
+        936
+      ],
+      [
+        140,
+        140
+      ]
+    ],
+    "textureRotated": false
+  },
+  "player_ball_43_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      -4
+    ],
+    "spriteSize": [
+      115,
+      100
+    ],
+    "spriteSourceSize": [
+      131,
+      108
+    ],
+    "textureRect": [
+      [
+        3148,
+        1401
+      ],
+      [
+        115,
+        100
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_01_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -43,
+      0
+    ],
+    "spriteSize": [
+      84,
+      306
+    ],
+    "spriteSourceSize": [
+      172,
+      310
+    ],
+    "textureRect": [
+      [
+        2165,
+        306
+      ],
+      [
+        84,
+        306
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_01_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      21,
+      -3
+    ],
+    "spriteSize": [
+      96,
+      300
+    ],
+    "spriteSourceSize": [
+      138,
+      308
+    ],
+    "textureRect": [
+      [
+        2468,
+        409
+      ],
+      [
+        96,
+        300
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_02_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -43,
+      0
+    ],
+    "spriteSize": [
+      84,
+      308
+    ],
+    "spriteSourceSize": [
+      172,
+      310
+    ],
+    "textureRect": [
+      [
+        1803,
+        384
+      ],
+      [
+        84,
+        308
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_02_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      21,
+      -3
+    ],
+    "spriteSize": [
+      96,
+      300
+    ],
+    "spriteSourceSize": [
+      138,
+      308
+    ],
+    "textureRect": [
+      [
+        2165,
+        493
+      ],
+      [
+        96,
+        300
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_03_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -47,
+      0
+    ],
+    "spriteSize": [
+      100,
+      308
+    ],
+    "spriteSourceSize": [
+      196,
+      310
+    ],
+    "textureRect": [
+      [
+        3249,
+        410
+      ],
+      [
+        100,
+        308
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_03_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      -1
+    ],
+    "spriteSize": [
+      134,
+      340
+    ],
+    "spriteSourceSize": [
+      178,
+      342
+    ],
+    "textureRect": [
+      [
+        2166,
+        171
+      ],
+      [
+        134,
+        340
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_04_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -47,
+      0
+    ],
+    "spriteSize": [
+      100,
+      308
+    ],
+    "spriteSourceSize": [
+      196,
+      310
+    ],
+    "textureRect": [
+      [
+        1359,
+        110
+      ],
+      [
+        100,
+        308
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_04_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      -1
+    ],
+    "spriteSize": [
+      134,
+      340
+    ],
+    "spriteSourceSize": [
+      178,
+      342
+    ],
+    "textureRect": [
+      [
+        2507,
+        171
+      ],
+      [
+        134,
+        340
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_05_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -30,
+      -1
+    ],
+    "spriteSize": [
+      200,
+      308
+    ],
+    "spriteSourceSize": [
+      260,
+      310
+    ],
+    "textureRect": [
+      [
+        3249,
+        8
+      ],
+      [
+        200,
+        308
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_05_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      30,
+      0
+    ],
+    "spriteSize": [
+      174,
+      362
+    ],
+    "spriteSourceSize": [
+      234,
+      362
+    ],
+    "textureRect": [
+      [
+        3568,
+        1
+      ],
+      [
+        174,
+        362
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_06_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -30,
+      -1
+    ],
+    "spriteSize": [
+      200,
+      308
+    ],
+    "spriteSourceSize": [
+      260,
+      310
+    ],
+    "textureRect": [
+      [
+        3249,
+        209
+      ],
+      [
+        200,
+        308
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_06_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      30,
+      0
+    ],
+    "spriteSize": [
+      174,
+      362
+    ],
+    "spriteSourceSize": [
+      234,
+      362
+    ],
+    "textureRect": [
+      [
+        1803,
+        8
+      ],
+      [
+        174,
+        362
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_07_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -47,
+      0
+    ],
+    "spriteSize": [
+      100,
+      308
+    ],
+    "spriteSourceSize": [
+      196,
+      310
+    ],
+    "textureRect": [
+      [
+        1022,
+        111
+      ],
+      [
+        100,
+        308
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_07_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      -1
+    ],
+    "spriteSize": [
+      134,
+      340
+    ],
+    "spriteSourceSize": [
+      178,
+      342
+    ],
+    "textureRect": [
+      [
+        2887,
+        314
+      ],
+      [
+        134,
+        340
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_08_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -49,
+      0
+    ],
+    "spriteSize": [
+      101,
+      302
+    ],
+    "spriteSourceSize": [
+      201,
+      302
+    ],
+    "textureRect": [
+      [
+        2165,
+        391
+      ],
+      [
+        101,
+        302
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_08_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      26,
+      0
+    ],
+    "spriteSize": [
+      124,
+      358
+    ],
+    "spriteSourceSize": [
+      176,
+      358
+    ],
+    "textureRect": [
+      [
+        3558,
+        176
+      ],
+      [
+        124,
+        358
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_09_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -49,
+      0
+    ],
+    "spriteSize": [
+      102,
+      302
+    ],
+    "spriteSourceSize": [
+      202,
+      302
+    ],
+    "textureRect": [
+      [
+        2472,
+        306
+      ],
+      [
+        102,
+        302
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_09_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      27,
+      -1
+    ],
+    "spriteSize": [
+      121,
+      356
+    ],
+    "spriteSourceSize": [
+      175,
+      358
+    ],
+    "textureRect": [
+      [
+        3558,
+        301
+      ],
+      [
+        121,
+        356
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_10_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -47,
+      0
+    ],
+    "spriteSize": [
+      100,
+      308
+    ],
+    "spriteSourceSize": [
+      196,
+      310
+    ],
+    "textureRect": [
+      [
+        1358,
+        211
+      ],
+      [
+        100,
+        308
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_10_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      -1
+    ],
+    "spriteSize": [
+      134,
+      340
+    ],
+    "spriteSourceSize": [
+      178,
+      342
+    ],
+    "textureRect": [
+      [
+        3558,
+        423
+      ],
+      [
+        134,
+        340
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_11_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -21,
+      -5
+    ],
+    "spriteSize": [
+      112,
+      288
+    ],
+    "spriteSourceSize": [
+      156,
+      298
+    ],
+    "textureRect": [
+      [
+        2887,
+        544
+      ],
+      [
+        112,
+        288
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_11_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      0
+    ],
+    "spriteSize": [
+      162,
+      360
+    ],
+    "spriteSourceSize": [
+      172,
+      360
+    ],
+    "textureRect": [
+      [
+        2166,
+        8
+      ],
+      [
+        162,
+        360
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_12_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -21,
+      -5
+    ],
+    "spriteSize": [
+      112,
+      288
+    ],
+    "spriteSourceSize": [
+      156,
+      298
+    ],
+    "textureRect": [
+      [
+        2466,
+        506
+      ],
+      [
+        112,
+        288
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_12_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      0
+    ],
+    "spriteSize": [
+      162,
+      360
+    ],
+    "spriteSourceSize": [
+      172,
+      360
+    ],
+    "textureRect": [
+      [
+        2527,
+        8
+      ],
+      [
+        162,
+        360
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_13_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -47,
+      0
+    ],
+    "spriteSize": [
+      100,
+      308
+    ],
+    "spriteSourceSize": [
+      196,
+      310
+    ],
+    "textureRect": [
+      [
+        1803,
+        183
+      ],
+      [
+        100,
+        308
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_13_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      -1
+    ],
+    "spriteSize": [
+      134,
+      340
+    ],
+    "spriteSourceSize": [
+      178,
+      342
+    ],
+    "textureRect": [
+      [
+        1,
+        10
+      ],
+      [
+        134,
+        340
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_14_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -46,
+      0
+    ],
+    "spriteSize": [
+      99,
+      308
+    ],
+    "spriteSourceSize": [
+      195,
+      310
+    ],
+    "textureRect": [
+      [
+        1803,
+        284
+      ],
+      [
+        99,
+        308
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_14_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      -1
+    ],
+    "spriteSize": [
+      134,
+      340
+    ],
+    "spriteSourceSize": [
+      178,
+      342
+    ],
+    "textureRect": [
+      [
+        342,
+        10
+      ],
+      [
+        134,
+        340
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_15_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -47,
+      -4
+    ],
+    "spriteSize": [
+      100,
+      336
+    ],
+    "spriteSourceSize": [
+      196,
+      344
+    ],
+    "textureRect": [
+      [
+        1022,
+        10
+      ],
+      [
+        100,
+        336
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_15_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      32,
+      0
+    ],
+    "spriteSize": [
+      152,
+      360
+    ],
+    "spriteSourceSize": [
+      220,
+      360
+    ],
+    "textureRect": [
+      [
+        2888,
+        8
+      ],
+      [
+        152,
+        360
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_16_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -46,
+      -5
+    ],
+    "spriteSize": [
+      99,
+      334
+    ],
+    "spriteSourceSize": [
+      195,
+      344
+    ],
+    "textureRect": [
+      [
+        1359,
+        10
+      ],
+      [
+        99,
+        334
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_16_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      32,
+      0
+    ],
+    "spriteSize": [
+      152,
+      360
+    ],
+    "spriteSourceSize": [
+      218,
+      360
+    ],
+    "textureRect": [
+      [
+        2888,
+        161
+      ],
+      [
+        152,
+        360
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_17_back_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -44,
+      0
+    ],
+    "spriteSize": [
+      94,
+      298
+    ],
+    "spriteSourceSize": [
+      184,
+      298
+    ],
+    "textureRect": [
+      [
+        2887,
+        449
+      ],
+      [
+        94,
+        298
+      ]
+    ],
+    "textureRotated": true
+  },
+  "portal_17_front_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      0
+    ],
+    "spriteSize": [
+      134,
+      338
+    ],
+    "spriteSourceSize": [
+      178,
+      338
+    ],
+    "textureRect": [
+      [
+        683,
+        10
+      ],
+      [
+        134,
+        338
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_01_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      110,
+      78
+    ],
+    "spriteSourceSize": [
+      112,
+      78
+    ],
+    "textureRect": [
+      [
+        1667,
+        2411
+      ],
+      [
+        110,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_01_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -7
+    ],
+    "spriteSize": [
+      96,
+      56
+    ],
+    "spriteSourceSize": [
+      96,
+      70
+    ],
+    "textureRect": [
+      [
+        3677,
+        2685
+      ],
+      [
+        96,
+        56
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_01_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      118,
+      86
+    ],
+    "spriteSourceSize": [
+      120,
+      86
+    ],
+    "textureRect": [
+      [
+        841,
+        2412
+      ],
+      [
+        118,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_01_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        122,
+        2032
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_01_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      6
+    ],
+    "spriteSourceSize": [
+      6,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        91
+      ],
+      [
+        6,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_01_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_01_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_01_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        3899,
+        423
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_01_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_01_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      54,
+      34
+    ],
+    "spriteSourceSize": [
+      54,
+      34
+    ],
+    "textureRect": [
+      [
+        122,
+        2791
+      ],
+      [
+        54,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_01_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      6
+    ],
+    "spriteSourceSize": [
+      6,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        91
+      ],
+      [
+        6,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_01_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      62,
+      42
+    ],
+    "spriteSourceSize": [
+      62,
+      42
+    ],
+    "textureRect": [
+      [
+        1933,
+        2722
+      ],
+      [
+        62,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_02_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      116,
+      78
+    ],
+    "spriteSourceSize": [
+      124,
+      78
+    ],
+    "textureRect": [
+      [
+        1449,
+        2147
+      ],
+      [
+        116,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_02_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      18,
+      8
+    ],
+    "spriteSize": [
+      44,
+      16
+    ],
+    "spriteSourceSize": [
+      80,
+      32
+    ],
+    "textureRect": [
+      [
+        1496,
+        994
+      ],
+      [
+        44,
+        16
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_02_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      126,
+      88
+    ],
+    "spriteSourceSize": [
+      134,
+      88
+    ],
+    "textureRect": [
+      [
+        2880,
+        1659
+      ],
+      [
+        126,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_02_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        122,
+        2087
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_02_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      14,
+      18
+    ],
+    "spriteSourceSize": [
+      14,
+      32
+    ],
+    "textureRect": [
+      [
+        1335,
+        1072
+      ],
+      [
+        14,
+        18
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_02_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3963,
+        3287
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_02_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_02_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        1334,
+        1170
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_02_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_02_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      32
+    ],
+    "spriteSourceSize": [
+      52,
+      32
+    ],
+    "textureRect": [
+      [
+        119,
+        2901
+      ],
+      [
+        52,
+        32
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_02_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      6
+    ],
+    "spriteSourceSize": [
+      6,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        91
+      ],
+      [
+        6,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_02_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      60,
+      40
+    ],
+    "spriteSourceSize": [
+      60,
+      40
+    ],
+    "textureRect": [
+      [
+        3630,
+        2930
+      ],
+      [
+        60,
+        40
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_03_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      5
+    ],
+    "spriteSize": [
+      120,
+      100
+    ],
+    "spriteSourceSize": [
+      122,
+      110
+    ],
+    "textureRect": [
+      [
+        3047,
+        1247
+      ],
+      [
+        120,
+        100
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_03_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      13
+    ],
+    "spriteSize": [
+      104,
+      80
+    ],
+    "spriteSourceSize": [
+      118,
+      106
+    ],
+    "textureRect": [
+      [
+        640,
+        1916
+      ],
+      [
+        104,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_03_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      5
+    ],
+    "spriteSize": [
+      128,
+      106
+    ],
+    "spriteSourceSize": [
+      130,
+      116
+    ],
+    "textureRect": [
+      [
+        2009,
+        1591
+      ],
+      [
+        128,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_03_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        122,
+        2142
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_03_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      32,
+      48
+    ],
+    "spriteSourceSize": [
+      32,
+      48
+    ],
+    "textureRect": [
+      [
+        112,
+        3060
+      ],
+      [
+        32,
+        48
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_03_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_03_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        1336,
+        894
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_03_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      6
+    ],
+    "spriteSourceSize": [
+      6,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        91
+      ],
+      [
+        6,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_03_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_03_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      32
+    ],
+    "spriteSourceSize": [
+      52,
+      32
+    ],
+    "textureRect": [
+      [
+        114,
+        2954
+      ],
+      [
+        52,
+        32
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_03_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      26
+    ],
+    "spriteSourceSize": [
+      46,
+      26
+    ],
+    "textureRect": [
+      [
+        3148,
+        788
+      ],
+      [
+        46,
+        26
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_03_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      62,
+      40
+    ],
+    "spriteSourceSize": [
+      62,
+      40
+    ],
+    "textureRect": [
+      [
+        3002,
+        1832
+      ],
+      [
+        62,
+        40
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_04_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      108
+    ],
+    "spriteSourceSize": [
+      120,
+      108
+    ],
+    "textureRect": [
+      [
+        280,
+        2608
+      ],
+      [
+        120,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_04_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      8
+    ],
+    "spriteSize": [
+      94,
+      86
+    ],
+    "spriteSourceSize": [
+      100,
+      102
+    ],
+    "textureRect": [
+      [
+        817,
+        2995
+      ],
+      [
+        94,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_04_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      128,
+      116
+    ],
+    "spriteSourceSize": [
+      130,
+      116
+    ],
+    "textureRect": [
+      [
+        2144,
+        1514
+      ],
+      [
+        128,
+        116
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_04_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        122,
+        2197
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_04_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      6
+    ],
+    "spriteSourceSize": [
+      6,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        91
+      ],
+      [
+        6,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_04_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_04_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_04_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        1334,
+        1170
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_04_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_04_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      54,
+      34
+    ],
+    "spriteSourceSize": [
+      54,
+      34
+    ],
+    "textureRect": [
+      [
+        1082,
+        2391
+      ],
+      [
+        54,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_04_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      6
+    ],
+    "spriteSourceSize": [
+      6,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        91
+      ],
+      [
+        6,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_04_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      62,
+      42
+    ],
+    "spriteSourceSize": [
+      62,
+      42
+    ],
+    "textureRect": [
+      [
+        1933,
+        2722
+      ],
+      [
+        62,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -2
+    ],
+    "spriteSize": [
+      104,
+      94
+    ],
+    "spriteSourceSize": [
+      104,
+      98
+    ],
+    "textureRect": [
+      [
+        3042,
+        2624
+      ],
+      [
+        104,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      28,
+      -2
+    ],
+    "spriteSize": [
+      42,
+      76
+    ],
+    "spriteSourceSize": [
+      98,
+      80
+    ],
+    "textureRect": [
+      [
+        1073,
+        2580
+      ],
+      [
+        42,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -2
+    ],
+    "spriteSize": [
+      112,
+      102
+    ],
+    "spriteSourceSize": [
+      112,
+      106
+    ],
+    "textureRect": [
+      [
+        276,
+        2796
+      ],
+      [
+        112,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        122,
+        2252
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      20,
+      20
+    ],
+    "spriteSourceSize": [
+      20,
+      34
+    ],
+    "textureRect": [
+      [
+        143,
+        1254
+      ],
+      [
+        20,
+        20
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_05_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        142,
+        1552
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      6
+    ],
+    "spriteSourceSize": [
+      6,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        91
+      ],
+      [
+        6,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      34
+    ],
+    "spriteSourceSize": [
+      56,
+      34
+    ],
+    "textureRect": [
+      [
+        1084,
+        2163
+      ],
+      [
+        56,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_05_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      11,
+      -7
+    ],
+    "spriteSize": [
+      28,
+      14
+    ],
+    "spriteSourceSize": [
+      50,
+      28
+    ],
+    "textureRect": [
+      [
+        3712,
+        1643
+      ],
+      [
+        28,
+        14
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_05_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      64,
+      42
+    ],
+    "spriteSourceSize": [
+      64,
+      42
+    ],
+    "textureRect": [
+      [
+        4031,
+        3156
+      ],
+      [
+        64,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_06_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      -5
+    ],
+    "spriteSize": [
+      126,
+      98
+    ],
+    "spriteSourceSize": [
+      138,
+      108
+    ],
+    "textureRect": [
+      [
+        2266,
+        1701
+      ],
+      [
+        126,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_06_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      -5
+    ],
+    "spriteSize": [
+      52,
+      42
+    ],
+    "spriteSourceSize": [
+      96,
+      52
+    ],
+    "textureRect": [
+      [
+        3796,
+        3235
+      ],
+      [
+        52,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_06_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      -5
+    ],
+    "spriteSize": [
+      134,
+      106
+    ],
+    "spriteSourceSize": [
+      146,
+      116
+    ],
+    "textureRect": [
+      [
+        1773,
+        1257
+      ],
+      [
+        134,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_06_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        1084,
+        1687
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_06_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      18,
+      20
+    ],
+    "spriteSourceSize": [
+      18,
+      34
+    ],
+    "textureRect": [
+      [
+        143,
+        1317
+      ],
+      [
+        18,
+        20
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_06_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_06_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        142,
+        1552
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_06_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      6
+    ],
+    "spriteSourceSize": [
+      6,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        91
+      ],
+      [
+        6,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_06_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_06_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      34
+    ],
+    "spriteSourceSize": [
+      56,
+      34
+    ],
+    "textureRect": [
+      [
+        1084,
+        2220
+      ],
+      [
+        56,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_06_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      6
+    ],
+    "spriteSourceSize": [
+      6,
+      6
+    ],
+    "textureRect": [
+      [
+        3558,
+        91
+      ],
+      [
+        6,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_06_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      64,
+      42
+    ],
+    "spriteSourceSize": [
+      64,
+      42
+    ],
+    "textureRect": [
+      [
+        4031,
+        3199
+      ],
+      [
+        64,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      7
+    ],
+    "spriteSize": [
+      132,
+      112
+    ],
+    "spriteSourceSize": [
+      138,
+      126
+    ],
+    "textureRect": [
+      [
+        1140,
+        1472
+      ],
+      [
+        132,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      15
+    ],
+    "spriteSize": [
+      110,
+      92
+    ],
+    "spriteSourceSize": [
+      118,
+      122
+    ],
+    "textureRect": [
+      [
+        147,
+        3025
+      ],
+      [
+        110,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      7
+    ],
+    "spriteSize": [
+      140,
+      120
+    ],
+    "spriteSourceSize": [
+      146,
+      134
+    ],
+    "textureRect": [
+      [
+        1795,
+        1077
+      ],
+      [
+        140,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      50,
+      54
+    ],
+    "spriteSourceSize": [
+      58,
+      54
+    ],
+    "textureRect": [
+      [
+        3912,
+        3313
+      ],
+      [
+        50,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -18,
+      0
+    ],
+    "spriteSize": [
+      18,
+      32
+    ],
+    "spriteSourceSize": [
+      54,
+      32
+    ],
+    "textureRect": [
+      [
+        1335,
+        945
+      ],
+      [
+        18,
+        32
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      58,
+      62
+    ],
+    "spriteSourceSize": [
+      66,
+      62
+    ],
+    "textureRect": [
+      [
+        3678,
+        2401
+      ],
+      [
+        58,
+        62
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        142,
+        1603
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        3899,
+        423
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      62,
+      34
+    ],
+    "spriteSourceSize": [
+      68,
+      34
+    ],
+    "textureRect": [
+      [
+        122,
+        2552
+      ],
+      [
+        62,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_07_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      18,
+      -4
+    ],
+    "spriteSize": [
+      24,
+      18
+    ],
+    "spriteSourceSize": [
+      60,
+      26
+    ],
+    "textureRect": [
+      [
+        4056,
+        1387
+      ],
+      [
+        24,
+        18
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_07_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      70,
+      42
+    ],
+    "spriteSourceSize": [
+      76,
+      42
+    ],
+    "textureRect": [
+      [
+        3627,
+        3062
+      ],
+      [
+        70,
+        42
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_08_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      12
+    ],
+    "spriteSize": [
+      114,
+      102
+    ],
+    "spriteSourceSize": [
+      116,
+      126
+    ],
+    "textureRect": [
+      [
+        3981,
+        2802
+      ],
+      [
+        114,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_08_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      29,
+      -2
+    ],
+    "spriteSize": [
+      48,
+      56
+    ],
+    "spriteSourceSize": [
+      106,
+      60
+    ],
+    "textureRect": [
+      [
+        1679,
+        2821
+      ],
+      [
+        48,
+        56
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_08_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      12
+    ],
+    "spriteSize": [
+      122,
+      110
+    ],
+    "spriteSourceSize": [
+      124,
+      134
+    ],
+    "textureRect": [
+      [
+        3557,
+        1705
+      ],
+      [
+        122,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_08_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        1084,
+        1742
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_08_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      16,
+      16
+    ],
+    "spriteSourceSize": [
+      16,
+      30
+    ],
+    "textureRect": [
+      [
+        1496,
+        1039
+      ],
+      [
+        16,
+        16
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_08_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_08_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        142,
+        1654
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_08_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_08_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_08_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      54,
+      34
+    ],
+    "spriteSourceSize": [
+      54,
+      34
+    ],
+    "textureRect": [
+      [
+        1082,
+        2446
+      ],
+      [
+        54,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_08_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      -1
+    ],
+    "spriteSize": [
+      14,
+      14
+    ],
+    "spriteSourceSize": [
+      20,
+      16
+    ],
+    "textureRect": [
+      [
+        1814,
+        890
+      ],
+      [
+        14,
+        14
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_08_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      62,
+      42
+    ],
+    "spriteSourceSize": [
+      62,
+      42
+    ],
+    "textureRect": [
+      [
+        1933,
+        2722
+      ],
+      [
+        62,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      10,
+      -5
+    ],
+    "spriteSize": [
+      116,
+      106
+    ],
+    "spriteSourceSize": [
+      136,
+      116
+    ],
+    "textureRect": [
+      [
+        3369,
+        2802
+      ],
+      [
+        116,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      9
+    ],
+    "spriteSize": [
+      102,
+      114
+    ],
+    "spriteSourceSize": [
+      118,
+      162
+    ],
+    "textureRect": [
+      [
+        3045,
+        1637
+      ],
+      [
+        102,
+        114
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      16,
+      0
+    ],
+    "spriteSize": [
+      104,
+      94
+    ],
+    "spriteSourceSize": [
+      136,
+      124
+    ],
+    "textureRect": [
+      [
+        3042,
+        2719
+      ],
+      [
+        104,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      10,
+      11
+    ],
+    "spriteSize": [
+      124,
+      148
+    ],
+    "spriteSourceSize": [
+      144,
+      170
+    ],
+    "textureRect": [
+      [
+        3750,
+        952
+      ],
+      [
+        124,
+        148
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_09_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        1084,
+        1742
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      16,
+      16
+    ],
+    "spriteSourceSize": [
+      16,
+      30
+    ],
+    "textureRect": [
+      [
+        1496,
+        1039
+      ],
+      [
+        16,
+        16
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_09_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        1799,
+        843
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      54,
+      34
+    ],
+    "spriteSourceSize": [
+      54,
+      34
+    ],
+    "textureRect": [
+      [
+        122,
+        2791
+      ],
+      [
+        54,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_09_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_09_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      62,
+      42
+    ],
+    "spriteSourceSize": [
+      62,
+      42
+    ],
+    "textureRect": [
+      [
+        1933,
+        2722
+      ],
+      [
+        62,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_10_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      6
+    ],
+    "spriteSize": [
+      154,
+      94
+    ],
+    "spriteSourceSize": [
+      160,
+      106
+    ],
+    "textureRect": [
+      [
+        3053,
+        884
+      ],
+      [
+        154,
+        94
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_10_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      28,
+      22
+    ],
+    "spriteSize": [
+      94,
+      52
+    ],
+    "spriteSourceSize": [
+      150,
+      96
+    ],
+    "textureRect": [
+      [
+        2990,
+        2227
+      ],
+      [
+        94,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_10_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      6
+    ],
+    "spriteSize": [
+      162,
+      102
+    ],
+    "spriteSourceSize": [
+      168,
+      114
+    ],
+    "textureRect": [
+      [
+        1194,
+        622
+      ],
+      [
+        162,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_10_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      50,
+      54
+    ],
+    "spriteSourceSize": [
+      58,
+      54
+    ],
+    "textureRect": [
+      [
+        3912,
+        3313
+      ],
+      [
+        50,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_10_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -18,
+      0
+    ],
+    "spriteSize": [
+      18,
+      32
+    ],
+    "spriteSourceSize": [
+      54,
+      32
+    ],
+    "textureRect": [
+      [
+        1335,
+        945
+      ],
+      [
+        18,
+        32
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_10_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      58,
+      62
+    ],
+    "spriteSourceSize": [
+      66,
+      62
+    ],
+    "textureRect": [
+      [
+        3678,
+        2401
+      ],
+      [
+        58,
+        62
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_10_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_10_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        3899,
+        423
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_10_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_10_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      62,
+      34
+    ],
+    "spriteSourceSize": [
+      68,
+      34
+    ],
+    "textureRect": [
+      [
+        122,
+        2552
+      ],
+      [
+        62,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_10_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      18,
+      -4
+    ],
+    "spriteSize": [
+      24,
+      18
+    ],
+    "spriteSourceSize": [
+      60,
+      26
+    ],
+    "textureRect": [
+      [
+        4056,
+        1387
+      ],
+      [
+        24,
+        18
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_10_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      70,
+      42
+    ],
+    "spriteSourceSize": [
+      76,
+      42
+    ],
+    "textureRect": [
+      [
+        3627,
+        3062
+      ],
+      [
+        70,
+        42
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_11_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      2
+    ],
+    "spriteSize": [
+      108,
+      84
+    ],
+    "spriteSourceSize": [
+      118,
+      88
+    ],
+    "textureRect": [
+      [
+        1843,
+        2528
+      ],
+      [
+        108,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_11_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      2
+    ],
+    "spriteSize": [
+      100,
+      80
+    ],
+    "spriteSourceSize": [
+      106,
+      84
+    ],
+    "textureRect": [
+      [
+        3148,
+        2032
+      ],
+      [
+        100,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_11_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      2
+    ],
+    "spriteSize": [
+      116,
+      92
+    ],
+    "spriteSourceSize": [
+      126,
+      96
+    ],
+    "textureRect": [
+      [
+        3733,
+        2963
+      ],
+      [
+        116,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_11_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        1084,
+        1742
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_11_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      16,
+      16
+    ],
+    "spriteSourceSize": [
+      16,
+      30
+    ],
+    "textureRect": [
+      [
+        1496,
+        1039
+      ],
+      [
+        16,
+        16
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_11_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_11_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_11_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        3899,
+        423
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_11_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_11_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      54,
+      34
+    ],
+    "spriteSourceSize": [
+      54,
+      34
+    ],
+    "textureRect": [
+      [
+        1082,
+        2446
+      ],
+      [
+        54,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_11_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      -1
+    ],
+    "spriteSize": [
+      14,
+      14
+    ],
+    "spriteSourceSize": [
+      20,
+      16
+    ],
+    "textureRect": [
+      [
+        1814,
+        890
+      ],
+      [
+        14,
+        14
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_11_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      62,
+      42
+    ],
+    "spriteSourceSize": [
+      62,
+      42
+    ],
+    "textureRect": [
+      [
+        1933,
+        2722
+      ],
+      [
+        62,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_12_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      9
+    ],
+    "spriteSize": [
+      124,
+      104
+    ],
+    "spriteSourceSize": [
+      138,
+      122
+    ],
+    "textureRect": [
+      [
+        2518,
+        1853
+      ],
+      [
+        124,
+        104
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_12_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      29,
+      28
+    ],
+    "spriteSize": [
+      68,
+      42
+    ],
+    "spriteSourceSize": [
+      126,
+      98
+    ],
+    "textureRect": [
+      [
+        3485,
+        3108
+      ],
+      [
+        68,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_12_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      9
+    ],
+    "spriteSize": [
+      131,
+      112
+    ],
+    "spriteSourceSize": [
+      145,
+      130
+    ],
+    "textureRect": [
+      [
+        2334,
+        723
+      ],
+      [
+        131,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_12_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        1084,
+        1742
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_12_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      16,
+      16
+    ],
+    "spriteSourceSize": [
+      16,
+      30
+    ],
+    "textureRect": [
+      [
+        1496,
+        1039
+      ],
+      [
+        16,
+        16
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_12_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_12_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_12_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        3899,
+        423
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_12_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_12_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      34
+    ],
+    "spriteSourceSize": [
+      56,
+      34
+    ],
+    "textureRect": [
+      [
+        122,
+        2677
+      ],
+      [
+        56,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_12_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      -5
+    ],
+    "spriteSize": [
+      32,
+      16
+    ],
+    "spriteSourceSize": [
+      48,
+      26
+    ],
+    "textureRect": [
+      [
+        3186,
+        449
+      ],
+      [
+        32,
+        16
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_12_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      64,
+      42
+    ],
+    "spriteSourceSize": [
+      64,
+      42
+    ],
+    "textureRect": [
+      [
+        3966,
+        3201
+      ],
+      [
+        64,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_13_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -1
+    ],
+    "spriteSize": [
+      122,
+      104
+    ],
+    "spriteSourceSize": [
+      126,
+      106
+    ],
+    "textureRect": [
+      [
+        3557,
+        1816
+      ],
+      [
+        122,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_13_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      8
+    ],
+    "spriteSize": [
+      112,
+      80
+    ],
+    "spriteSourceSize": [
+      112,
+      96
+    ],
+    "textureRect": [
+      [
+        2961,
+        2600
+      ],
+      [
+        112,
+        80
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_13_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      6
+    ],
+    "spriteSize": [
+      18,
+      14
+    ],
+    "spriteSourceSize": [
+      62,
+      26
+    ],
+    "textureRect": [
+      [
+        1335,
+        1057
+      ],
+      [
+        18,
+        14
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_13_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -1
+    ],
+    "spriteSize": [
+      131,
+      112
+    ],
+    "spriteSourceSize": [
+      135,
+      114
+    ],
+    "textureRect": [
+      [
+        2753,
+        1364
+      ],
+      [
+        131,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_13_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      44,
+      60
+    ],
+    "spriteSourceSize": [
+      44,
+      60
+    ],
+    "textureRect": [
+      [
+        1618,
+        2868
+      ],
+      [
+        44,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_13_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      18,
+      26
+    ],
+    "spriteSourceSize": [
+      18,
+      30
+    ],
+    "textureRect": [
+      [
+        325,
+        505
+      ],
+      [
+        18,
+        26
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_13_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      66
+    ],
+    "spriteSourceSize": [
+      52,
+      66
+    ],
+    "textureRect": [
+      [
+        3418,
+        2909
+      ],
+      [
+        52,
+        66
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_13_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_13_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        1799,
+        843
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_13_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_13_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      64,
+      38
+    ],
+    "spriteSourceSize": [
+      66,
+      38
+    ],
+    "textureRect": [
+      [
+        122,
+        1849
+      ],
+      [
+        64,
+        38
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_13_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -10,
+      4
+    ],
+    "spriteSize": [
+      22,
+      14
+    ],
+    "spriteSourceSize": [
+      42,
+      22
+    ],
+    "textureRect": [
+      [
+        143,
+        1218
+      ],
+      [
+        22,
+        14
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_13_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      72,
+      46
+    ],
+    "spriteSourceSize": [
+      74,
+      46
+    ],
+    "textureRect": [
+      [
+        3250,
+        3016
+      ],
+      [
+        72,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_14_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      10
+    ],
+    "spriteSize": [
+      132,
+      104
+    ],
+    "spriteSourceSize": [
+      142,
+      124
+    ],
+    "textureRect": [
+      [
+        858,
+        1581
+      ],
+      [
+        132,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_14_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      11
+    ],
+    "spriteSize": [
+      126,
+      98
+    ],
+    "spriteSourceSize": [
+      136,
+      120
+    ],
+    "textureRect": [
+      [
+        2885,
+        1374
+      ],
+      [
+        126,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_14_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      10
+    ],
+    "spriteSize": [
+      140,
+      112
+    ],
+    "spriteSourceSize": [
+      150,
+      132
+    ],
+    "textureRect": [
+      [
+        1652,
+        1115
+      ],
+      [
+        140,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_14_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      44,
+      58
+    ],
+    "spriteSourceSize": [
+      46,
+      58
+    ],
+    "textureRect": [
+      [
+        3678,
+        2523
+      ],
+      [
+        44,
+        58
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_14_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_14_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      52,
+      66
+    ],
+    "spriteSourceSize": [
+      56,
+      66
+    ],
+    "textureRect": [
+      [
+        3248,
+        3063
+      ],
+      [
+        52,
+        66
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_14_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_14_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        3899,
+        423
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_14_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_14_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      54,
+      34
+    ],
+    "spriteSourceSize": [
+      54,
+      34
+    ],
+    "textureRect": [
+      [
+        122,
+        2791
+      ],
+      [
+        54,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_14_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_14_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      62,
+      42
+    ],
+    "spriteSourceSize": [
+      62,
+      42
+    ],
+    "textureRect": [
+      [
+        1933,
+        2722
+      ],
+      [
+        62,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_15_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      110,
+      98
+    ],
+    "spriteSourceSize": [
+      116,
+      98
+    ],
+    "textureRect": [
+      [
+        1229,
+        2455
+      ],
+      [
+        110,
+        98
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_15_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      20,
+      0
+    ],
+    "spriteSize": [
+      72,
+      92
+    ],
+    "spriteSourceSize": [
+      112,
+      92
+    ],
+    "textureRect": [
+      [
+        2440,
+        2534
+      ],
+      [
+        72,
+        92
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_15_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      117,
+      106
+    ],
+    "spriteSourceSize": [
+      123,
+      106
+    ],
+    "textureRect": [
+      [
+        2516,
+        1978
+      ],
+      [
+        117,
+        106
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_15_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      48,
+      64
+    ],
+    "spriteSourceSize": [
+      48,
+      66
+    ],
+    "textureRect": [
+      [
+        3850,
+        3171
+      ],
+      [
+        48,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_15_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      18,
+      20
+    ],
+    "spriteSourceSize": [
+      18,
+      34
+    ],
+    "textureRect": [
+      [
+        143,
+        1336
+      ],
+      [
+        18,
+        20
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_15_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      56,
+      72
+    ],
+    "spriteSourceSize": [
+      56,
+      74
+    ],
+    "textureRect": [
+      [
+        3412,
+        3023
+      ],
+      [
+        56,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_15_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_15_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        1799,
+        843
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_15_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_15_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      64,
+      38
+    ],
+    "spriteSourceSize": [
+      66,
+      38
+    ],
+    "textureRect": [
+      [
+        122,
+        1849
+      ],
+      [
+        64,
+        38
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_15_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -10,
+      4
+    ],
+    "spriteSize": [
+      22,
+      14
+    ],
+    "spriteSourceSize": [
+      42,
+      22
+    ],
+    "textureRect": [
+      [
+        143,
+        1218
+      ],
+      [
+        22,
+        14
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_15_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      72,
+      46
+    ],
+    "spriteSourceSize": [
+      74,
+      46
+    ],
+    "textureRect": [
+      [
+        3250,
+        3016
+      ],
+      [
+        72,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      7
+    ],
+    "spriteSize": [
+      114,
+      110
+    ],
+    "spriteSourceSize": [
+      130,
+      124
+    ],
+    "textureRect": [
+      [
+        3981,
+        2584
+      ],
+      [
+        114,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      6
+    ],
+    "spriteSize": [
+      110,
+      102
+    ],
+    "spriteSourceSize": [
+      126,
+      114
+    ],
+    "textureRect": [
+      [
+        381,
+        2950
+      ],
+      [
+        110,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      35,
+      0
+    ],
+    "spriteSize": [
+      50,
+      16
+    ],
+    "spriteSourceSize": [
+      120,
+      16
+    ],
+    "textureRect": [
+      [
+        1496,
+        943
+      ],
+      [
+        50,
+        16
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_16_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      7
+    ],
+    "spriteSize": [
+      121,
+      118
+    ],
+    "spriteSourceSize": [
+      137,
+      132
+    ],
+    "textureRect": [
+      [
+        3370,
+        2566
+      ],
+      [
+        121,
+        118
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      56
+    ],
+    "textureRect": [
+      [
+        1084,
+        1797
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      45,
+      62
+    ],
+    "spriteSourceSize": [
+      45,
+      64
+    ],
+    "textureRect": [
+      [
+        4050,
+        1695
+      ],
+      [
+        45,
+        62
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        142,
+        1603
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_16_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      52,
+      38
+    ],
+    "spriteSourceSize": [
+      52,
+      40
+    ],
+    "textureRect": [
+      [
+        122,
+        2362
+      ],
+      [
+        52,
+        38
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_16_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      46,
+      32
+    ],
+    "spriteSourceSize": [
+      46,
+      34
+    ],
+    "textureRect": [
+      [
+        112,
+        3109
+      ],
+      [
+        46,
+        32
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_16_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      60,
+      46
+    ],
+    "spriteSourceSize": [
+      60,
+      46
+    ],
+    "textureRect": [
+      [
+        1728,
+        2796
+      ],
+      [
+        60,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_17_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      7
+    ],
+    "spriteSize": [
+      132,
+      134
+    ],
+    "spriteSourceSize": [
+      136,
+      148
+    ],
+    "textureRect": [
+      [
+        1531,
+        494
+      ],
+      [
+        132,
+        134
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_17_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      13
+    ],
+    "spriteSize": [
+      126,
+      120
+    ],
+    "spriteSourceSize": [
+      134,
+      146
+    ],
+    "textureRect": [
+      [
+        1586,
+        1960
+      ],
+      [
+        126,
+        120
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_17_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      31,
+      -15
+    ],
+    "spriteSize": [
+      50,
+      60
+    ],
+    "spriteSourceSize": [
+      112,
+      90
+    ],
+    "textureRect": [
+      [
+        3915,
+        3191
+      ],
+      [
+        50,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_17_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      7
+    ],
+    "spriteSize": [
+      140,
+      142
+    ],
+    "spriteSourceSize": [
+      144,
+      156
+    ],
+    "textureRect": [
+      [
+        503,
+        855
+      ],
+      [
+        140,
+        142
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_17_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      48,
+      64
+    ],
+    "spriteSourceSize": [
+      48,
+      66
+    ],
+    "textureRect": [
+      [
+        3850,
+        3171
+      ],
+      [
+        48,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_17_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      18,
+      20
+    ],
+    "spriteSourceSize": [
+      18,
+      34
+    ],
+    "textureRect": [
+      [
+        143,
+        1336
+      ],
+      [
+        18,
+        20
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_17_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      56,
+      72
+    ],
+    "spriteSourceSize": [
+      56,
+      74
+    ],
+    "textureRect": [
+      [
+        3412,
+        3023
+      ],
+      [
+        56,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_17_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        142,
+        1603
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_17_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_17_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_17_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      52,
+      38
+    ],
+    "spriteSourceSize": [
+      52,
+      40
+    ],
+    "textureRect": [
+      [
+        122,
+        2362
+      ],
+      [
+        52,
+        38
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_17_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      46,
+      32
+    ],
+    "spriteSourceSize": [
+      46,
+      34
+    ],
+    "textureRect": [
+      [
+        112,
+        3109
+      ],
+      [
+        46,
+        32
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_17_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      60,
+      46
+    ],
+    "spriteSourceSize": [
+      60,
+      46
+    ],
+    "textureRect": [
+      [
+        1728,
+        2796
+      ],
+      [
+        60,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_18_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      126,
+      92
+    ],
+    "spriteSourceSize": [
+      126,
+      98
+    ],
+    "textureRect": [
+      [
+        2753,
+        1477
+      ],
+      [
+        126,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_18_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      2
+    ],
+    "spriteSize": [
+      108,
+      50
+    ],
+    "spriteSourceSize": [
+      120,
+      54
+    ],
+    "textureRect": [
+      [
+        1792,
+        2287
+      ],
+      [
+        108,
+        50
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_18_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      134,
+      100
+    ],
+    "spriteSourceSize": [
+      134,
+      106
+    ],
+    "textureRect": [
+      [
+        3148,
+        1016
+      ],
+      [
+        134,
+        100
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_18_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      10
+    ],
+    "spriteSize": [
+      54,
+      82
+    ],
+    "spriteSourceSize": [
+      54,
+      102
+    ],
+    "textureRect": [
+      [
+        2944,
+        2812
+      ],
+      [
+        54,
+        82
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_18_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      8
+    ],
+    "spriteSize": [
+      44,
+      78
+    ],
+    "spriteSourceSize": [
+      44,
+      94
+    ],
+    "textureRect": [
+      [
+        1148,
+        1080
+      ],
+      [
+        44,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_18_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      10
+    ],
+    "spriteSize": [
+      62,
+      90
+    ],
+    "spriteSourceSize": [
+      62,
+      110
+    ],
+    "textureRect": [
+      [
+        3493,
+        2430
+      ],
+      [
+        62,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_18_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      16,
+      50
+    ],
+    "spriteSourceSize": [
+      16,
+      50
+    ],
+    "textureRect": [
+      [
+        3432,
+        1084
+      ],
+      [
+        16,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_18_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_18_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      24,
+      58
+    ],
+    "spriteSourceSize": [
+      24,
+      58
+    ],
+    "textureRect": [
+      [
+        3716,
+        1402
+      ],
+      [
+        24,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_18_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      59,
+      32
+    ],
+    "spriteSourceSize": [
+      59,
+      32
+    ],
+    "textureRect": [
+      [
+        3012,
+        1504
+      ],
+      [
+        59,
+        32
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_18_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      42,
+      26
+    ],
+    "spriteSourceSize": [
+      50,
+      26
+    ],
+    "textureRect": [
+      [
+        3712,
+        1658
+      ],
+      [
+        42,
+        26
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_18_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      67,
+      40
+    ],
+    "spriteSourceSize": [
+      67,
+      40
+    ],
+    "textureRect": [
+      [
+        462,
+        799
+      ],
+      [
+        67,
+        40
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_19_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -23,
+      4
+    ],
+    "spriteSize": [
+      176,
+      110
+    ],
+    "spriteSourceSize": [
+      222,
+      118
+    ],
+    "textureRect": [
+      [
+        184,
+        226
+      ],
+      [
+        176,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      130,
+      96
+    ],
+    "spriteSourceSize": [
+      134,
+      96
+    ],
+    "textureRect": [
+      [
+        1737,
+        1558
+      ],
+      [
+        130,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -23,
+      4
+    ],
+    "spriteSize": [
+      184,
+      118
+    ],
+    "spriteSourceSize": [
+      230,
+      126
+    ],
+    "textureRect": [
+      [
+        3899,
+        975
+      ],
+      [
+        184,
+        118
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      50,
+      54
+    ],
+    "spriteSourceSize": [
+      58,
+      54
+    ],
+    "textureRect": [
+      [
+        3912,
+        3313
+      ],
+      [
+        50,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -18,
+      0
+    ],
+    "spriteSize": [
+      18,
+      30
+    ],
+    "spriteSourceSize": [
+      54,
+      30
+    ],
+    "textureRect": [
+      [
+        1335,
+        1009
+      ],
+      [
+        18,
+        30
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      0
+    ],
+    "spriteSize": [
+      58,
+      62
+    ],
+    "spriteSourceSize": [
+      66,
+      62
+    ],
+    "textureRect": [
+      [
+        3678,
+        2401
+      ],
+      [
+        58,
+        62
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        1498,
+        796
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      61,
+      34
+    ],
+    "spriteSourceSize": [
+      67,
+      34
+    ],
+    "textureRect": [
+      [
+        122,
+        2615
+      ],
+      [
+        61,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_19_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      18,
+      -4
+    ],
+    "spriteSize": [
+      23,
+      18
+    ],
+    "spriteSourceSize": [
+      59,
+      26
+    ],
+    "textureRect": [
+      [
+        149,
+        606
+      ],
+      [
+        23,
+        18
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_19_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      69,
+      42
+    ],
+    "spriteSourceSize": [
+      75,
+      42
+    ],
+    "textureRect": [
+      [
+        3485,
+        2924
+      ],
+      [
+        69,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      9
+    ],
+    "spriteSize": [
+      146,
+      96
+    ],
+    "spriteSourceSize": [
+      156,
+      114
+    ],
+    "textureRect": [
+      [
+        174,
+        594
+      ],
+      [
+        146,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -8,
+      8
+    ],
+    "spriteSize": [
+      134,
+      88
+    ],
+    "spriteSourceSize": [
+      150,
+      104
+    ],
+    "textureRect": [
+      [
+        1330,
+        1429
+      ],
+      [
+        134,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      9
+    ],
+    "spriteSize": [
+      154,
+      104
+    ],
+    "spriteSourceSize": [
+      164,
+      122
+    ],
+    "textureRect": [
+      [
+        3557,
+        1600
+      ],
+      [
+        154,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      46,
+      56
+    ],
+    "spriteSourceSize": [
+      48,
+      56
+    ],
+    "textureRect": [
+      [
+        1679,
+        2878
+      ],
+      [
+        46,
+        56
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      38,
+      38
+    ],
+    "spriteSourceSize": [
+      40,
+      38
+    ],
+    "textureRect": [
+      [
+        122,
+        2415
+      ],
+      [
+        38,
+        38
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      54,
+      64
+    ],
+    "spriteSourceSize": [
+      56,
+      64
+    ],
+    "textureRect": [
+      [
+        3850,
+        3063
+      ],
+      [
+        54,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_20_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      22,
+      50
+    ],
+    "spriteSourceSize": [
+      22,
+      50
+    ],
+    "textureRect": [
+      [
+        144,
+        1032
+      ],
+      [
+        22,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      46
+    ],
+    "spriteSourceSize": [
+      18,
+      46
+    ],
+    "textureRect": [
+      [
+        1498,
+        896
+      ],
+      [
+        18,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      30,
+      58
+    ],
+    "spriteSourceSize": [
+      30,
+      58
+    ],
+    "textureRect": [
+      [
+        473,
+        558
+      ],
+      [
+        30,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      61,
+      34
+    ],
+    "spriteSourceSize": [
+      67,
+      34
+    ],
+    "textureRect": [
+      [
+        1084,
+        2101
+      ],
+      [
+        61,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_20_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      13,
+      -5
+    ],
+    "spriteSize": [
+      33,
+      20
+    ],
+    "spriteSourceSize": [
+      59,
+      30
+    ],
+    "textureRect": [
+      [
+        3750,
+        894
+      ],
+      [
+        33,
+        20
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_20_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      69,
+      42
+    ],
+    "spriteSourceSize": [
+      75,
+      42
+    ],
+    "textureRect": [
+      [
+        3485,
+        2967
+      ],
+      [
+        69,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      115,
+      106
+    ],
+    "spriteSourceSize": [
+      115,
+      114
+    ],
+    "textureRect": [
+      [
+        524,
+        2112
+      ],
+      [
+        115,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      11
+    ],
+    "spriteSize": [
+      109,
+      86
+    ],
+    "spriteSourceSize": [
+      113,
+      108
+    ],
+    "textureRect": [
+      [
+        1439,
+        2481
+      ],
+      [
+        109,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      4
+    ],
+    "spriteSize": [
+      123,
+      114
+    ],
+    "spriteSourceSize": [
+      123,
+      122
+    ],
+    "textureRect": [
+      [
+        1968,
+        1944
+      ],
+      [
+        123,
+        114
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        122,
+        2307
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      8
+    ],
+    "spriteSize": [
+      32,
+      32
+    ],
+    "spriteSourceSize": [
+      32,
+      48
+    ],
+    "textureRect": [
+      [
+        3750,
+        915
+      ],
+      [
+        32,
+        32
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        4026,
+        3328
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_21_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      10,
+      26
+    ],
+    "spriteSourceSize": [
+      10,
+      26
+    ],
+    "textureRect": [
+      [
+        4084,
+        1005
+      ],
+      [
+        10,
+        26
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        1814,
+        843
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      59,
+      36
+    ],
+    "spriteSourceSize": [
+      65,
+      36
+    ],
+    "textureRect": [
+      [
+        3679,
+        1975
+      ],
+      [
+        59,
+        36
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      18,
+      -3
+    ],
+    "spriteSize": [
+      27,
+      26
+    ],
+    "spriteSourceSize": [
+      63,
+      32
+    ],
+    "textureRect": [
+      [
+        1331,
+        111
+      ],
+      [
+        27,
+        26
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_21_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      67,
+      44
+    ],
+    "spriteSourceSize": [
+      73,
+      44
+    ],
+    "textureRect": [
+      [
+        2096,
+        1175
+      ],
+      [
+        67,
+        44
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_22_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      117,
+      98
+    ],
+    "spriteSourceSize": [
+      117,
+      100
+    ],
+    "textureRect": [
+      [
+        3147,
+        2492
+      ],
+      [
+        117,
+        98
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_22_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      7
+    ],
+    "spriteSize": [
+      102,
+      66
+    ],
+    "spriteSourceSize": [
+      108,
+      80
+    ],
+    "textureRect": [
+      [
+        1952,
+        2588
+      ],
+      [
+        102,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_22_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      125,
+      106
+    ],
+    "spriteSourceSize": [
+      125,
+      108
+    ],
+    "textureRect": [
+      [
+        2624,
+        1665
+      ],
+      [
+        125,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_22_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      42,
+      60
+    ],
+    "spriteSourceSize": [
+      42,
+      62
+    ],
+    "textureRect": [
+      [
+        1728,
+        2843
+      ],
+      [
+        42,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_22_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      24,
+      54
+    ],
+    "spriteSourceSize": [
+      24,
+      56
+    ],
+    "textureRect": [
+      [
+        3716,
+        1461
+      ],
+      [
+        24,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_22_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      50,
+      68
+    ],
+    "spriteSourceSize": [
+      50,
+      70
+    ],
+    "textureRect": [
+      [
+        3485,
+        3010
+      ],
+      [
+        50,
+        68
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_22_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        142,
+        1603
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_22_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_22_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_22_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      0
+    ],
+    "spriteSize": [
+      59,
+      38
+    ],
+    "spriteSourceSize": [
+      63,
+      38
+    ],
+    "textureRect": [
+      [
+        3679,
+        1936
+      ],
+      [
+        59,
+        38
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_22_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -14,
+      -5
+    ],
+    "spriteSize": [
+      22,
+      22
+    ],
+    "spriteSourceSize": [
+      50,
+      32
+    ],
+    "textureRect": [
+      [
+        143,
+        1195
+      ],
+      [
+        22,
+        22
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_22_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      0
+    ],
+    "spriteSize": [
+      67,
+      46
+    ],
+    "spriteSourceSize": [
+      71,
+      46
+    ],
+    "textureRect": [
+      [
+        2096,
+        1128
+      ],
+      [
+        67,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_23_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      2
+    ],
+    "spriteSize": [
+      115,
+      102
+    ],
+    "spriteSourceSize": [
+      123,
+      106
+    ],
+    "textureRect": [
+      [
+        3045,
+        1521
+      ],
+      [
+        115,
+        102
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_23_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      1
+    ],
+    "spriteSize": [
+      109,
+      94
+    ],
+    "spriteSourceSize": [
+      117,
+      96
+    ],
+    "textureRect": [
+      [
+        621,
+        2814
+      ],
+      [
+        109,
+        94
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_23_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      2
+    ],
+    "spriteSize": [
+      123,
+      110
+    ],
+    "spriteSourceSize": [
+      131,
+      114
+    ],
+    "textureRect": [
+      [
+        1843,
+        1986
+      ],
+      [
+        123,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_23_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      54,
+      54
+    ],
+    "spriteSourceSize": [
+      56,
+      54
+    ],
+    "textureRect": [
+      [
+        1423,
+        2916
+      ],
+      [
+        54,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_23_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -13
+    ],
+    "spriteSize": [
+      20,
+      20
+    ],
+    "spriteSourceSize": [
+      20,
+      46
+    ],
+    "textureRect": [
+      [
+        143,
+        1275
+      ],
+      [
+        20,
+        20
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_23_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      62,
+      60
+    ],
+    "spriteSourceSize": [
+      64,
+      60
+    ],
+    "textureRect": [
+      [
+        3670,
+        3113
+      ],
+      [
+        62,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_23_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        1498,
+        796
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_23_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_23_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_23_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      1
+    ],
+    "spriteSize": [
+      65,
+      40
+    ],
+    "spriteSourceSize": [
+      69,
+      42
+    ],
+    "textureRect": [
+      [
+        1152,
+        1014
+      ],
+      [
+        65,
+        40
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_23_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      1
+    ],
+    "spriteSize": [
+      26,
+      32
+    ],
+    "spriteSourceSize": [
+      28,
+      34
+    ],
+    "textureRect": [
+      [
+        3712,
+        1701
+      ],
+      [
+        26,
+        32
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_23_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      1
+    ],
+    "spriteSize": [
+      73,
+      48
+    ],
+    "spriteSourceSize": [
+      77,
+      50
+    ],
+    "textureRect": [
+      [
+        2366,
+        2593
+      ],
+      [
+        73,
+        48
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_24_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      11
+    ],
+    "spriteSize": [
+      109,
+      118
+    ],
+    "spriteSourceSize": [
+      125,
+      140
+    ],
+    "textureRect": [
+      [
+        1119,
+        2227
+      ],
+      [
+        109,
+        118
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_24_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      16,
+      -3
+    ],
+    "spriteSize": [
+      87,
+      70
+    ],
+    "spriteSourceSize": [
+      119,
+      76
+    ],
+    "textureRect": [
+      [
+        1754,
+        2725
+      ],
+      [
+        87,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_24_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      11
+    ],
+    "spriteSize": [
+      117,
+      126
+    ],
+    "spriteSourceSize": [
+      133,
+      148
+    ],
+    "textureRect": [
+      [
+        2769,
+        487
+      ],
+      [
+        117,
+        126
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_24_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      54
+    ],
+    "spriteSourceSize": [
+      38,
+      54
+    ],
+    "textureRect": [
+      [
+        1084,
+        1742
+      ],
+      [
+        38,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_24_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      16,
+      18
+    ],
+    "spriteSourceSize": [
+      16,
+      32
+    ],
+    "textureRect": [
+      [
+        1335,
+        1040
+      ],
+      [
+        16,
+        18
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_24_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      46,
+      62
+    ],
+    "spriteSourceSize": [
+      46,
+      62
+    ],
+    "textureRect": [
+      [
+        3849,
+        3267
+      ],
+      [
+        46,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_24_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_24_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        1814,
+        843
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_24_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_24_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      54,
+      34
+    ],
+    "spriteSourceSize": [
+      54,
+      34
+    ],
+    "textureRect": [
+      [
+        119,
+        2846
+      ],
+      [
+        54,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_24_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      -1
+    ],
+    "spriteSize": [
+      14,
+      14
+    ],
+    "spriteSourceSize": [
+      20,
+      16
+    ],
+    "textureRect": [
+      [
+        1814,
+        905
+      ],
+      [
+        14,
+        14
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_24_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      62,
+      42
+    ],
+    "spriteSourceSize": [
+      62,
+      42
+    ],
+    "textureRect": [
+      [
+        1933,
+        2722
+      ],
+      [
+        62,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      4
+    ],
+    "spriteSize": [
+      126,
+      90
+    ],
+    "spriteSourceSize": [
+      130,
+      98
+    ],
+    "textureRect": [
+      [
+        2880,
+        1568
+      ],
+      [
+        126,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      120,
+      68
+    ],
+    "spriteSourceSize": [
+      120,
+      68
+    ],
+    "textureRect": [
+      [
+        1,
+        2748
+      ],
+      [
+        120,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      4
+    ],
+    "spriteSize": [
+      136,
+      98
+    ],
+    "spriteSourceSize": [
+      138,
+      106
+    ],
+    "textureRect": [
+      [
+        1332,
+        1330
+      ],
+      [
+        136,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      42,
+      56
+    ],
+    "spriteSourceSize": [
+      42,
+      56
+    ],
+    "textureRect": [
+      [
+        1617,
+        2913
+      ],
+      [
+        42,
+        56
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_25_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      9
+    ],
+    "spriteSize": [
+      38,
+      32
+    ],
+    "spriteSourceSize": [
+      38,
+      50
+    ],
+    "textureRect": [
+      [
+        1084,
+        1960
+      ],
+      [
+        38,
+        32
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      50,
+      64
+    ],
+    "spriteSourceSize": [
+      50,
+      64
+    ],
+    "textureRect": [
+      [
+        3799,
+        3056
+      ],
+      [
+        50,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        1814,
+        843
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      61,
+      36
+    ],
+    "spriteSourceSize": [
+      67,
+      36
+    ],
+    "textureRect": [
+      [
+        122,
+        2454
+      ],
+      [
+        61,
+        36
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_25_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -3
+    ],
+    "spriteSize": [
+      20,
+      22
+    ],
+    "spriteSourceSize": [
+      20,
+      28
+    ],
+    "textureRect": [
+      [
+        1336,
+        794
+      ],
+      [
+        20,
+        22
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_25_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      0
+    ],
+    "spriteSize": [
+      71,
+      44
+    ],
+    "spriteSourceSize": [
+      75,
+      44
+    ],
+    "textureRect": [
+      [
+        1148,
+        1159
+      ],
+      [
+        71,
+        44
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_26_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      11,
+      6
+    ],
+    "spriteSize": [
+      118,
+      128
+    ],
+    "spriteSourceSize": [
+      140,
+      140
+    ],
+    "textureRect": [
+      [
+        1330,
+        1831
+      ],
+      [
+        118,
+        128
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_26_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      25,
+      13
+    ],
+    "spriteSize": [
+      84,
+      104
+    ],
+    "spriteSourceSize": [
+      134,
+      130
+    ],
+    "textureRect": [
+      [
+        3264,
+        2786
+      ],
+      [
+        84,
+        104
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_26_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      11,
+      6
+    ],
+    "spriteSize": [
+      126,
+      136
+    ],
+    "spriteSourceSize": [
+      148,
+      148
+    ],
+    "textureRect": [
+      [
+        1666,
+        534
+      ],
+      [
+        126,
+        136
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_26_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      48,
+      66
+    ],
+    "spriteSourceSize": [
+      48,
+      68
+    ],
+    "textureRect": [
+      [
+        3315,
+        3082
+      ],
+      [
+        48,
+        66
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_26_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      42,
+      60
+    ],
+    "spriteSourceSize": [
+      42,
+      60
+    ],
+    "textureRect": [
+      [
+        1509,
+        2890
+      ],
+      [
+        42,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_26_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      56,
+      74
+    ],
+    "spriteSourceSize": [
+      56,
+      76
+    ],
+    "textureRect": [
+      [
+        3189,
+        2919
+      ],
+      [
+        56,
+        74
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_26_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      18,
+      50
+    ],
+    "spriteSourceSize": [
+      18,
+      50
+    ],
+    "textureRect": [
+      [
+        873,
+        496
+      ],
+      [
+        18,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_26_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      14,
+      46
+    ],
+    "spriteSourceSize": [
+      14,
+      46
+    ],
+    "textureRect": [
+      [
+        1799,
+        890
+      ],
+      [
+        14,
+        46
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_26_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      26,
+      58
+    ],
+    "spriteSourceSize": [
+      26,
+      58
+    ],
+    "textureRect": [
+      [
+        3148,
+        729
+      ],
+      [
+        26,
+        58
+      ]
+    ],
+    "textureRotated": false
+  },
+  "robot_26_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -2
+    ],
+    "spriteSize": [
+      58,
+      32
+    ],
+    "spriteSourceSize": [
+      62,
+      36
+    ],
+    "textureRect": [
+      [
+        3012,
+        1564
+      ],
+      [
+        58,
+        32
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_26_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      -2
+    ],
+    "spriteSize": [
+      38,
+      26
+    ],
+    "spriteSourceSize": [
+      50,
+      30
+    ],
+    "textureRect": [
+      [
+        3148,
+        835
+      ],
+      [
+        38,
+        26
+      ]
+    ],
+    "textureRotated": true
+  },
+  "robot_26_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -2
+    ],
+    "spriteSize": [
+      66,
+      40
+    ],
+    "spriteSourceSize": [
+      70,
+      44
+    ],
+    "textureRect": [
+      [
+        1152,
+        947
+      ],
+      [
+        66,
+        40
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      149,
+      90
+    ],
+    "spriteSourceSize": [
+      149,
+      90
+    ],
+    "textureRect": [
+      [
+        722,
+        558
+      ],
+      [
+        149,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      20
+    ],
+    "spriteSize": [
+      96,
+      42
+    ],
+    "spriteSourceSize": [
+      104,
+      82
+    ],
+    "textureRect": [
+      [
+        1800,
+        2081
+      ],
+      [
+        96,
+        42
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      149,
+      88
+    ],
+    "spriteSourceSize": [
+      149,
+      90
+    ],
+    "textureRect": [
+      [
+        872,
+        627
+      ],
+      [
+        149,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      1
+    ],
+    "spriteSize": [
+      112,
+      78
+    ],
+    "spriteSourceSize": [
+      122,
+      80
+    ],
+    "textureRect": [
+      [
+        637,
+        2592
+      ],
+      [
+        112,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      0
+    ],
+    "spriteSize": [
+      167,
+      92
+    ],
+    "spriteSourceSize": [
+      179,
+      92
+    ],
+    "textureRect": [
+      [
+        2466,
+        694
+      ],
+      [
+        167,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      -15
+    ],
+    "spriteSize": [
+      157,
+      44
+    ],
+    "spriteSourceSize": [
+      169,
+      74
+    ],
+    "textureRect": [
+      [
+        3249,
+        1487
+      ],
+      [
+        157,
+        44
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      1
+    ],
+    "spriteSize": [
+      179,
+      102
+    ],
+    "spriteSourceSize": [
+      185,
+      104
+    ],
+    "textureRect": [
+      [
+        550,
+        210
+      ],
+      [
+        179,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -9,
+      -12
+    ],
+    "spriteSize": [
+      143,
+      66
+    ],
+    "spriteSourceSize": [
+      161,
+      90
+    ],
+    "textureRect": [
+      [
+        1829,
+        661
+      ],
+      [
+        143,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_05_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      -4
+    ],
+    "spriteSize": [
+      162,
+      88
+    ],
+    "spriteSourceSize": [
+      168,
+      96
+    ],
+    "textureRect": [
+      [
+        1666,
+        754
+      ],
+      [
+        162,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_05_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      -9
+    ],
+    "spriteSize": [
+      135,
+      68
+    ],
+    "spriteSourceSize": [
+      143,
+      86
+    ],
+    "textureRect": [
+      [
+        1531,
+        425
+      ],
+      [
+        135,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_06_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      0
+    ],
+    "spriteSize": [
+      172,
+      96
+    ],
+    "spriteSourceSize": [
+      182,
+      96
+    ],
+    "textureRect": [
+      [
+        1358,
+        411
+      ],
+      [
+        172,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_06_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      0
+    ],
+    "spriteSize": [
+      164,
+      88
+    ],
+    "spriteSourceSize": [
+      174,
+      88
+    ],
+    "textureRect": [
+      [
+        2887,
+        965
+      ],
+      [
+        164,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_07_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      -3
+    ],
+    "spriteSize": [
+      166,
+      80
+    ],
+    "spriteSourceSize": [
+      180,
+      86
+    ],
+    "textureRect": [
+      [
+        2165,
+        833
+      ],
+      [
+        166,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_07_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      115,
+      64
+    ],
+    "spriteSourceSize": [
+      115,
+      64
+    ],
+    "textureRect": [
+      [
+        524,
+        2219
+      ],
+      [
+        115,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_08_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      -1
+    ],
+    "spriteSize": [
+      166,
+      90
+    ],
+    "spriteSourceSize": [
+      178,
+      92
+    ],
+    "textureRect": [
+      [
+        2165,
+        742
+      ],
+      [
+        166,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_08_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      1
+    ],
+    "spriteSize": [
+      158,
+      76
+    ],
+    "spriteSourceSize": [
+      168,
+      78
+    ],
+    "textureRect": [
+      [
+        3557,
+        1412
+      ],
+      [
+        158,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_09_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -5
+    ],
+    "spriteSize": [
+      174,
+      94
+    ],
+    "spriteSourceSize": [
+      174,
+      104
+    ],
+    "textureRect": [
+      [
+        1022,
+        212
+      ],
+      [
+        174,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_09_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -11
+    ],
+    "spriteSize": [
+      168,
+      74
+    ],
+    "spriteSourceSize": [
+      168,
+      96
+    ],
+    "textureRect": [
+      [
+        2165,
+        667
+      ],
+      [
+        168,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_10_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      -6
+    ],
+    "spriteSize": [
+      160,
+      96
+    ],
+    "spriteSourceSize": [
+      168,
+      108
+    ],
+    "textureRect": [
+      [
+        2465,
+        963
+      ],
+      [
+        160,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_10_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -19
+    ],
+    "spriteSize": [
+      146,
+      64
+    ],
+    "spriteSourceSize": [
+      146,
+      102
+    ],
+    "textureRect": [
+      [
+        1,
+        628
+      ],
+      [
+        146,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_11_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      -8
+    ],
+    "spriteSize": [
+      174,
+      92
+    ],
+    "spriteSourceSize": [
+      188,
+      108
+    ],
+    "textureRect": [
+      [
+        1022,
+        307
+      ],
+      [
+        174,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_11_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -11,
+      -1
+    ],
+    "spriteSize": [
+      121,
+      64
+    ],
+    "spriteSourceSize": [
+      143,
+      66
+    ],
+    "textureRect": [
+      [
+        3555,
+        2647
+      ],
+      [
+        121,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_12_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      -8
+    ],
+    "spriteSize": [
+      162,
+      96
+    ],
+    "spriteSourceSize": [
+      176,
+      112
+    ],
+    "textureRect": [
+      [
+        3557,
+        1236
+      ],
+      [
+        162,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_12_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      137,
+      70
+    ],
+    "spriteSourceSize": [
+      141,
+      70
+    ],
+    "textureRect": [
+      [
+        1974,
+        564
+      ],
+      [
+        137,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_13_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      -2
+    ],
+    "spriteSize": [
+      158,
+      88
+    ],
+    "spriteSourceSize": [
+      164,
+      92
+    ],
+    "textureRect": [
+      [
+        3249,
+        1278
+      ],
+      [
+        158,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_13_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      -12
+    ],
+    "spriteSize": [
+      152,
+      62
+    ],
+    "spriteSourceSize": [
+      158,
+      86
+    ],
+    "textureRect": [
+      [
+        659,
+        392
+      ],
+      [
+        152,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_14_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -7
+    ],
+    "spriteSize": [
+      156,
+      84
+    ],
+    "spriteSourceSize": [
+      160,
+      98
+    ],
+    "textureRect": [
+      [
+        3899,
+        1387
+      ],
+      [
+        156,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_14_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -9
+    ],
+    "spriteSize": [
+      150,
+      68
+    ],
+    "spriteSourceSize": [
+      154,
+      86
+    ],
+    "textureRect": [
+      [
+        722,
+        422
+      ],
+      [
+        150,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_15_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      -4
+    ],
+    "spriteSize": [
+      162,
+      92
+    ],
+    "spriteSourceSize": [
+      172,
+      100
+    ],
+    "textureRect": [
+      [
+        1666,
+        661
+      ],
+      [
+        162,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_15_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      -3
+    ],
+    "spriteSize": [
+      148,
+      66
+    ],
+    "spriteSourceSize": [
+      164,
+      72
+    ],
+    "textureRect": [
+      [
+        655,
+        545
+      ],
+      [
+        148,
+        66
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_16_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -7
+    ],
+    "spriteSize": [
+      176,
+      90
+    ],
+    "spriteSourceSize": [
+      180,
+      104
+    ],
+    "textureRect": [
+      [
+        730,
+        226
+      ],
+      [
+        176,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_16_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      -3
+    ],
+    "spriteSize": [
+      168,
+      74
+    ],
+    "spriteSourceSize": [
+      174,
+      80
+    ],
+    "textureRect": [
+      [
+        2466,
+        619
+      ],
+      [
+        168,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_17_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      175,
+      76
+    ],
+    "spriteSourceSize": [
+      175,
+      76
+    ],
+    "textureRect": [
+      [
+        361,
+        315
+      ],
+      [
+        175,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_17_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -8,
+      0
+    ],
+    "spriteSize": [
+      155,
+      72
+    ],
+    "spriteSourceSize": [
+      171,
+      72
+    ],
+    "textureRect": [
+      [
+        3898,
+        1541
+      ],
+      [
+        155,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_18_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      -4
+    ],
+    "spriteSize": [
+      178,
+      72
+    ],
+    "spriteSourceSize": [
+      188,
+      80
+    ],
+    "textureRect": [
+      [
+        3917,
+        290
+      ],
+      [
+        178,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_18_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      -4
+    ],
+    "spriteSize": [
+      143,
+      64
+    ],
+    "spriteSourceSize": [
+      155,
+      72
+    ],
+    "textureRect": [
+      [
+        1829,
+        728
+      ],
+      [
+        143,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_19_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      0
+    ],
+    "spriteSize": [
+      184,
+      80
+    ],
+    "spriteSourceSize": [
+      198,
+      80
+    ],
+    "textureRect": [
+      [
+        3899,
+        1094
+      ],
+      [
+        184,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_19_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      6
+    ],
+    "spriteSize": [
+      148,
+      60
+    ],
+    "spriteSourceSize": [
+      160,
+      72
+    ],
+    "textureRect": [
+      [
+        176,
+        478
+      ],
+      [
+        148,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_20_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      14,
+      2
+    ],
+    "spriteSize": [
+      172,
+      104
+    ],
+    "spriteSourceSize": [
+      200,
+      108
+    ],
+    "textureRect": [
+      [
+        722,
+        317
+      ],
+      [
+        172,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_20_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      17,
+      2
+    ],
+    "spriteSize": [
+      134,
+      98
+    ],
+    "spriteSourceSize": [
+      168,
+      102
+    ],
+    "textureRect": [
+      [
+        1908,
+        1322
+      ],
+      [
+        134,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_21_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      -6
+    ],
+    "spriteSize": [
+      196,
+      82
+    ],
+    "spriteSourceSize": [
+      210,
+      94
+    ],
+    "textureRect": [
+      [
+        3899,
+        601
+      ],
+      [
+        196,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_21_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -10,
+      -7
+    ],
+    "spriteSize": [
+      154,
+      64
+    ],
+    "spriteSourceSize": [
+      174,
+      78
+    ],
+    "textureRect": [
+      [
+        3741,
+        1647
+      ],
+      [
+        154,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_22_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      7
+    ],
+    "spriteSize": [
+      176,
+      94
+    ],
+    "spriteSourceSize": [
+      176,
+      108
+    ],
+    "textureRect": [
+      [
+        1,
+        335
+      ],
+      [
+        176,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_22_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      52,
+      -3
+    ],
+    "spriteSize": [
+      16,
+      32
+    ],
+    "spriteSourceSize": [
+      120,
+      38
+    ],
+    "textureRect": [
+      [
+        3414,
+        1102
+      ],
+      [
+        16,
+        32
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_23_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      11
+    ],
+    "spriteSize": [
+      158,
+      106
+    ],
+    "spriteSourceSize": [
+      172,
+      128
+    ],
+    "textureRect": [
+      [
+        3249,
+        1171
+      ],
+      [
+        158,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_23_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      17
+    ],
+    "spriteSize": [
+      142,
+      84
+    ],
+    "spriteSourceSize": [
+      158,
+      118
+    ],
+    "textureRect": [
+      [
+        312,
+        1017
+      ],
+      [
+        142,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_24_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      3
+    ],
+    "spriteSize": [
+      162,
+      84
+    ],
+    "spriteSourceSize": [
+      164,
+      90
+    ],
+    "textureRect": [
+      [
+        2165,
+        914
+      ],
+      [
+        162,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_24_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      1
+    ],
+    "spriteSize": [
+      128,
+      52
+    ],
+    "spriteSourceSize": [
+      142,
+      54
+    ],
+    "textureRect": [
+      [
+        2112,
+        706
+      ],
+      [
+        128,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_25_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -2
+    ],
+    "spriteSize": [
+      186,
+      86
+    ],
+    "spriteSourceSize": [
+      186,
+      90
+    ],
+    "textureRect": [
+      [
+        3557,
+        1066
+      ],
+      [
+        186,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_25_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      9
+    ],
+    "spriteSize": [
+      140,
+      52
+    ],
+    "spriteSourceSize": [
+      142,
+      70
+    ],
+    "textureRect": [
+      [
+        2112,
+        295
+      ],
+      [
+        140,
+        52
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_26_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      0
+    ],
+    "spriteSize": [
+      171,
+      96
+    ],
+    "spriteSourceSize": [
+      185,
+      96
+    ],
+    "textureRect": [
+      [
+        1022,
+        546
+      ],
+      [
+        171,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_26_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -9,
+      0
+    ],
+    "spriteSize": [
+      130,
+      88
+    ],
+    "spriteSourceSize": [
+      148,
+      88
+    ],
+    "textureRect": [
+      [
+        1598,
+        1560
+      ],
+      [
+        130,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_26_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      -8
+    ],
+    "spriteSize": [
+      165,
+      72
+    ],
+    "spriteSourceSize": [
+      179,
+      88
+    ],
+    "textureRect": [
+      [
+        3176,
+        627
+      ],
+      [
+        165,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_27_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      -2
+    ],
+    "spriteSize": [
+      169,
+      86
+    ],
+    "spriteSourceSize": [
+      177,
+      90
+    ],
+    "textureRect": [
+      [
+        1803,
+        574
+      ],
+      [
+        169,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_27_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      -2
+    ],
+    "spriteSize": [
+      165,
+      82
+    ],
+    "spriteSourceSize": [
+      173,
+      86
+    ],
+    "textureRect": [
+      [
+        2466,
+        880
+      ],
+      [
+        165,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_27_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      82,
+      22
+    ],
+    "spriteSourceSize": [
+      84,
+      22
+    ],
+    "textureRect": [
+      [
+        149,
+        625
+      ],
+      [
+        82,
+        22
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_28_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      -6
+    ],
+    "spriteSize": [
+      165,
+      80
+    ],
+    "spriteSourceSize": [
+      171,
+      92
+    ],
+    "textureRect": [
+      [
+        2887,
+        884
+      ],
+      [
+        165,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_28_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      -6
+    ],
+    "spriteSize": [
+      161,
+      76
+    ],
+    "spriteSourceSize": [
+      167,
+      88
+    ],
+    "textureRect": [
+      [
+        2164,
+        1070
+      ],
+      [
+        161,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_28_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -398.5,
+      398.5
+    ],
+    "spriteSize": [
+      3,
+      3
+    ],
+    "spriteSourceSize": [
+      800,
+      800
+    ],
+    "textureRect": [
+      [
+        3558,
+        108
+      ],
+      [
+        3,
+        3
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_29_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      -6
+    ],
+    "spriteSize": [
+      180,
+      80
+    ],
+    "spriteSourceSize": [
+      186,
+      92
+    ],
+    "textureRect": [
+      [
+        733,
+        145
+      ],
+      [
+        180,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_29_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -9,
+      -5
+    ],
+    "spriteSize": [
+      152,
+      74
+    ],
+    "spriteSourceSize": [
+      170,
+      84
+    ],
+    "textureRect": [
+      [
+        353,
+        392
+      ],
+      [
+        152,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_29_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      33,
+      -7
+    ],
+    "spriteSize": [
+      67,
+      50
+    ],
+    "spriteSourceSize": [
+      133,
+      64
+    ],
+    "textureRect": [
+      [
+        2096,
+        1077
+      ],
+      [
+        67,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_30_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      -5
+    ],
+    "spriteSize": [
+      182,
+      86
+    ],
+    "spriteSourceSize": [
+      194,
+      96
+    ],
+    "textureRect": [
+      [
+        1,
+        145
+      ],
+      [
+        182,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_30_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -16
+    ],
+    "spriteSize": [
+      55,
+      14
+    ],
+    "spriteSourceSize": [
+      59,
+      46
+    ],
+    "textureRect": [
+      [
+        444,
+        1545
+      ],
+      [
+        55,
+        14
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_30_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      60,
+      10
+    ],
+    "spriteSize": [
+      31,
+      16
+    ],
+    "spriteSourceSize": [
+      151,
+      36
+    ],
+    "textureRect": [
+      [
+        3526,
+        579
+      ],
+      [
+        31,
+        16
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_31_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      12
+    ],
+    "spriteSize": [
+      169,
+      106
+    ],
+    "spriteSourceSize": [
+      175,
+      130
+    ],
+    "textureRect": [
+      [
+        3450,
+        995
+      ],
+      [
+        169,
+        106
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_31_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -8
+    ],
+    "spriteSize": [
+      159,
+      60
+    ],
+    "spriteSourceSize": [
+      159,
+      76
+    ],
+    "textureRect": [
+      [
+        2887,
+        1188
+      ],
+      [
+        159,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_31_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      65,
+      -2
+    ],
+    "spriteSize": [
+      37,
+      34
+    ],
+    "spriteSourceSize": [
+      167,
+      38
+    ],
+    "textureRect": [
+      [
+        3007,
+        1662
+      ],
+      [
+        37,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_32_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      15,
+      -3
+    ],
+    "spriteSize": [
+      195,
+      88
+    ],
+    "spriteSourceSize": [
+      225,
+      94
+    ],
+    "textureRect": [
+      [
+        3899,
+        684
+      ],
+      [
+        195,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_32_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      -12
+    ],
+    "spriteSize": [
+      156,
+      66
+    ],
+    "spriteSourceSize": [
+      160,
+      90
+    ],
+    "textureRect": [
+      [
+        3741,
+        1503
+      ],
+      [
+        156,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_32_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      0
+    ],
+    "spriteSize": [
+      147,
+      70
+    ],
+    "spriteSourceSize": [
+      191,
+      70
+    ],
+    "textureRect": [
+      [
+        1,
+        557
+      ],
+      [
+        147,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_33_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      9,
+      -7
+    ],
+    "spriteSize": [
+      183,
+      98
+    ],
+    "spriteSourceSize": [
+      201,
+      112
+    ],
+    "textureRect": [
+      [
+        3899,
+        1175
+      ],
+      [
+        183,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_33_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      -7
+    ],
+    "spriteSize": [
+      177,
+      94
+    ],
+    "spriteSourceSize": [
+      193,
+      108
+    ],
+    "textureRect": [
+      [
+        367,
+        220
+      ],
+      [
+        177,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_34_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      -6
+    ],
+    "spriteSize": [
+      167,
+      114
+    ],
+    "spriteSourceSize": [
+      175,
+      126
+    ],
+    "textureRect": [
+      [
+        3784,
+        784
+      ],
+      [
+        167,
+        114
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_34_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      10,
+      -4
+    ],
+    "spriteSize": [
+      151,
+      72
+    ],
+    "spriteSourceSize": [
+      171,
+      80
+    ],
+    "textureRect": [
+      [
+        506,
+        461
+      ],
+      [
+        151,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_35_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      -5
+    ],
+    "spriteSize": [
+      206,
+      84
+    ],
+    "spriteSourceSize": [
+      216,
+      94
+    ],
+    "textureRect": [
+      [
+        3249,
+        833
+      ],
+      [
+        206,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_35_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      -6
+    ],
+    "spriteSize": [
+      200,
+      78
+    ],
+    "spriteSourceSize": [
+      210,
+      90
+    ],
+    "textureRect": [
+      [
+        3249,
+        918
+      ],
+      [
+        200,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_35_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      32,
+      1
+    ],
+    "spriteSize": [
+      17,
+      12
+    ],
+    "spriteSourceSize": [
+      81,
+      14
+    ],
+    "textureRect": [
+      [
+        3917,
+        176
+      ],
+      [
+        17,
+        12
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_36_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      -8
+    ],
+    "spriteSize": [
+      172,
+      94
+    ],
+    "spriteSourceSize": [
+      180,
+      110
+    ],
+    "textureRect": [
+      [
+        1022,
+        400
+      ],
+      [
+        172,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_36_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -13
+    ],
+    "spriteSize": [
+      154,
+      76
+    ],
+    "spriteSourceSize": [
+      154,
+      102
+    ],
+    "textureRect": [
+      [
+        3741,
+        1570
+      ],
+      [
+        154,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_36_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      -16
+    ],
+    "spriteSize": [
+      100,
+      60
+    ],
+    "spriteSourceSize": [
+      114,
+      92
+    ],
+    "textureRect": [
+      [
+        3148,
+        2332
+      ],
+      [
+        100,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_37_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      -6
+    ],
+    "spriteSize": [
+      182,
+      74
+    ],
+    "spriteSourceSize": [
+      188,
+      86
+    ],
+    "textureRect": [
+      [
+        367,
+        145
+      ],
+      [
+        182,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_37_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      -6
+    ],
+    "spriteSize": [
+      172,
+      50
+    ],
+    "spriteSourceSize": [
+      178,
+      62
+    ],
+    "textureRect": [
+      [
+        1022,
+        495
+      ],
+      [
+        172,
+        50
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_38_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      182,
+      112
+    ],
+    "spriteSourceSize": [
+      184,
+      112
+    ],
+    "textureRect": [
+      [
+        3899,
+        1274
+      ],
+      [
+        182,
+        112
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_38_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      -2
+    ],
+    "spriteSize": [
+      172,
+      98
+    ],
+    "spriteSourceSize": [
+      176,
+      102
+    ],
+    "textureRect": [
+      [
+        1358,
+        312
+      ],
+      [
+        172,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_38_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -13,
+      -16
+    ],
+    "spriteSize": [
+      148,
+      54
+    ],
+    "spriteSourceSize": [
+      174,
+      86
+    ],
+    "textureRect": [
+      [
+        176,
+        539
+      ],
+      [
+        148,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_39_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      1
+    ],
+    "spriteSize": [
+      190,
+      86
+    ],
+    "spriteSourceSize": [
+      204,
+      88
+    ],
+    "textureRect": [
+      [
+        3557,
+        979
+      ],
+      [
+        190,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_39_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -8,
+      -4
+    ],
+    "spriteSize": [
+      182,
+      64
+    ],
+    "spriteSourceSize": [
+      198,
+      72
+    ],
+    "textureRect": [
+      [
+        550,
+        145
+      ],
+      [
+        182,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_40_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      -9
+    ],
+    "spriteSize": [
+      182,
+      80
+    ],
+    "spriteSourceSize": [
+      192,
+      98
+    ],
+    "textureRect": [
+      [
+        184,
+        145
+      ],
+      [
+        182,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_40_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -9,
+      -5
+    ],
+    "spriteSize": [
+      160,
+      62
+    ],
+    "spriteSourceSize": [
+      178,
+      72
+    ],
+    "textureRect": [
+      [
+        3186,
+        466
+      ],
+      [
+        160,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_40_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      30,
+      2
+    ],
+    "spriteSize": [
+      76,
+      18
+    ],
+    "spriteSourceSize": [
+      136,
+      22
+    ],
+    "textureRect": [
+      [
+        1336,
+        817
+      ],
+      [
+        76,
+        18
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_41_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      -9
+    ],
+    "spriteSize": [
+      166,
+      92
+    ],
+    "spriteSourceSize": [
+      172,
+      110
+    ],
+    "textureRect": [
+      [
+        2466,
+        787
+      ],
+      [
+        166,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_41_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      -9
+    ],
+    "spriteSize": [
+      158,
+      86
+    ],
+    "spriteSourceSize": [
+      164,
+      104
+    ],
+    "textureRect": [
+      [
+        3249,
+        1367
+      ],
+      [
+        158,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_41_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      36,
+      -2
+    ],
+    "spriteSize": [
+      10,
+      6
+    ],
+    "spriteSourceSize": [
+      82,
+      10
+    ],
+    "textureRect": [
+      [
+        3558,
+        80
+      ],
+      [
+        10,
+        6
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_42_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -3
+    ],
+    "spriteSize": [
+      192,
+      84
+    ],
+    "spriteSourceSize": [
+      192,
+      90
+    ],
+    "textureRect": [
+      [
+        3557,
+        894
+      ],
+      [
+        192,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_42_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      -3
+    ],
+    "spriteSize": [
+      176,
+      78
+    ],
+    "spriteSourceSize": [
+      188,
+      84
+    ],
+    "textureRect": [
+      [
+        545,
+        313
+      ],
+      [
+        176,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_43_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      -4
+    ],
+    "spriteSize": [
+      178,
+      92
+    ],
+    "spriteSourceSize": [
+      182,
+      100
+    ],
+    "textureRect": [
+      [
+        3917,
+        197
+      ],
+      [
+        178,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_43_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      -4
+    ],
+    "spriteSize": [
+      160,
+      86
+    ],
+    "spriteSourceSize": [
+      162,
+      94
+    ],
+    "textureRect": [
+      [
+        2465,
+        1060
+      ],
+      [
+        160,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_44_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      0
+    ],
+    "spriteSize": [
+      206,
+      94
+    ],
+    "spriteSourceSize": [
+      220,
+      94
+    ],
+    "textureRect": [
+      [
+        3249,
+        738
+      ],
+      [
+        206,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_44_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      -1
+    ],
+    "spriteSize": [
+      192,
+      86
+    ],
+    "spriteSourceSize": [
+      200,
+      88
+    ],
+    "textureRect": [
+      [
+        3899,
+        888
+      ],
+      [
+        192,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_45_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      -6
+    ],
+    "spriteSize": [
+      168,
+      76
+    ],
+    "spriteSourceSize": [
+      170,
+      88
+    ],
+    "textureRect": [
+      [
+        2165,
+        590
+      ],
+      [
+        168,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_45_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      -5
+    ],
+    "spriteSize": [
+      162,
+      70
+    ],
+    "spriteSourceSize": [
+      164,
+      80
+    ],
+    "textureRect": [
+      [
+        2164,
+        999
+      ],
+      [
+        162,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_46_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      -3
+    ],
+    "spriteSize": [
+      184,
+      82
+    ],
+    "spriteSourceSize": [
+      194,
+      88
+    ],
+    "textureRect": [
+      [
+        3557,
+        1153
+      ],
+      [
+        184,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_46_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      -3
+    ],
+    "spriteSize": [
+      164,
+      68
+    ],
+    "spriteSourceSize": [
+      166,
+      74
+    ],
+    "textureRect": [
+      [
+        3249,
+        1102
+      ],
+      [
+        164,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_47_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      2
+    ],
+    "spriteSize": [
+      192,
+      114
+    ],
+    "spriteSourceSize": [
+      198,
+      118
+    ],
+    "textureRect": [
+      [
+        3899,
+        773
+      ],
+      [
+        192,
+        114
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_47_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      2
+    ],
+    "spriteSize": [
+      182,
+      104
+    ],
+    "spriteSourceSize": [
+      184,
+      108
+    ],
+    "textureRect": [
+      [
+        3249,
+        997
+      ],
+      [
+        182,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_47_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      21,
+      27
+    ],
+    "spriteSize": [
+      106,
+      54
+    ],
+    "spriteSourceSize": [
+      148,
+      108
+    ],
+    "textureRect": [
+      [
+        1114,
+        2818
+      ],
+      [
+        106,
+        54
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_48_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -11,
+      -5
+    ],
+    "spriteSize": [
+      180,
+      108
+    ],
+    "spriteSourceSize": [
+      202,
+      118
+    ],
+    "textureRect": [
+      [
+        3915,
+        363
+      ],
+      [
+        180,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_48_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -9,
+      -6
+    ],
+    "spriteSize": [
+      170,
+      100
+    ],
+    "spriteSourceSize": [
+      188,
+      112
+    ],
+    "textureRect": [
+      [
+        3456,
+        824
+      ],
+      [
+        170,
+        100
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_48_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      49,
+      8
+    ],
+    "spriteSize": [
+      8,
+      6
+    ],
+    "spriteSourceSize": [
+      106,
+      22
+    ],
+    "textureRect": [
+      [
+        3558,
+        25
+      ],
+      [
+        8,
+        6
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_49_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      0
+    ],
+    "spriteSize": [
+      170,
+      104
+    ],
+    "spriteSourceSize": [
+      182,
+      104
+    ],
+    "textureRect": [
+      [
+        1803,
+        469
+      ],
+      [
+        170,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_49_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      0
+    ],
+    "spriteSize": [
+      164,
+      100
+    ],
+    "spriteSourceSize": [
+      178,
+      100
+    ],
+    "textureRect": [
+      [
+        3931,
+        1
+      ],
+      [
+        164,
+        100
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_49_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      13,
+      3
+    ],
+    "spriteSize": [
+      126,
+      28
+    ],
+    "spriteSourceSize": [
+      152,
+      34
+    ],
+    "textureRect": [
+      [
+        3712,
+        1516
+      ],
+      [
+        126,
+        28
+      ]
+    ],
+    "textureRotated": true
+  },
+  "ship_50_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      3
+    ],
+    "spriteSize": [
+      152,
+      92
+    ],
+    "spriteSourceSize": [
+      152,
+      98
+    ],
+    "textureRect": [
+      [
+        3402,
+        1611
+      ],
+      [
+        152,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_50_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      2
+    ],
+    "spriteSize": [
+      132,
+      80
+    ],
+    "spriteSourceSize": [
+      142,
+      84
+    ],
+    "textureRect": [
+      [
+        1330,
+        1631
+      ],
+      [
+        132,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_50_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      49,
+      -5
+    ],
+    "spriteSize": [
+      50,
+      44
+    ],
+    "spriteSourceSize": [
+      148,
+      54
+    ],
+    "textureRect": [
+      [
+        1533,
+        2941
+      ],
+      [
+        50,
+        44
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_51_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      3
+    ],
+    "spriteSize": [
+      176,
+      102
+    ],
+    "spriteSourceSize": [
+      184,
+      108
+    ],
+    "textureRect": [
+      [
+        1,
+        232
+      ],
+      [
+        176,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "ship_51_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      2,
+      3
+    ],
+    "spriteSize": [
+      164,
+      94
+    ],
+    "spriteSourceSize": [
+      168,
+      100
+    ],
+    "textureRect": [
+      [
+        3931,
+        102
+      ],
+      [
+        164,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      118,
+      78
+    ],
+    "spriteSourceSize": [
+      118,
+      78
+    ],
+    "textureRect": [
+      [
+        278,
+        2717
+      ],
+      [
+        118,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      25,
+      6
+    ],
+    "spriteSize": [
+      37,
+      38
+    ],
+    "spriteSourceSize": [
+      87,
+      50
+    ],
+    "textureRect": [
+      [
+        3007,
+        1623
+      ],
+      [
+        37,
+        38
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      25,
+      6
+    ],
+    "spriteSize": [
+      35,
+      36
+    ],
+    "spriteSourceSize": [
+      85,
+      48
+    ],
+    "textureRect": [
+      [
+        122,
+        2516
+      ],
+      [
+        35,
+        36
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_01_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      126,
+      86
+    ],
+    "spriteSourceSize": [
+      126,
+      86
+    ],
+    "textureRect": [
+      [
+        2624,
+        1578
+      ],
+      [
+        126,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      44,
+      62
+    ],
+    "spriteSourceSize": [
+      44,
+      62
+    ],
+    "textureRect": [
+      [
+        3963,
+        3334
+      ],
+      [
+        44,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_01_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      70
+    ],
+    "spriteSourceSize": [
+      52,
+      70
+    ],
+    "textureRect": [
+      [
+        3177,
+        3025
+      ],
+      [
+        52,
+        70
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_01_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      74
+    ],
+    "spriteSourceSize": [
+      38,
+      74
+    ],
+    "textureRect": [
+      [
+        2848,
+        329
+      ],
+      [
+        38,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      47,
+      82
+    ],
+    "spriteSourceSize": [
+      47,
+      82
+    ],
+    "textureRect": [
+      [
+        1145,
+        1389
+      ],
+      [
+        47,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      55,
+      34
+    ],
+    "spriteSourceSize": [
+      55,
+      34
+    ],
+    "textureRect": [
+      [
+        444,
+        1510
+      ],
+      [
+        55,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_01_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      42
+    ],
+    "spriteSourceSize": [
+      63,
+      42
+    ],
+    "textureRect": [
+      [
+        2561,
+        1513
+      ],
+      [
+        63,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_02_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      5
+    ],
+    "spriteSize": [
+      133,
+      102
+    ],
+    "spriteSourceSize": [
+      139,
+      112
+    ],
+    "textureRect": [
+      [
+        2753,
+        1120
+      ],
+      [
+        133,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_02_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      11
+    ],
+    "spriteSize": [
+      123,
+      82
+    ],
+    "spriteSourceSize": [
+      131,
+      104
+    ],
+    "textureRect": [
+      [
+        3373,
+        1704
+      ],
+      [
+        123,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_02_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      26,
+      5
+    ],
+    "spriteSize": [
+      35,
+      38
+    ],
+    "spriteSourceSize": [
+      87,
+      48
+    ],
+    "textureRect": [
+      [
+        1084,
+        1889
+      ],
+      [
+        35,
+        38
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_02_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      5
+    ],
+    "spriteSize": [
+      141,
+      110
+    ],
+    "spriteSourceSize": [
+      147,
+      120
+    ],
+    "textureRect": [
+      [
+        1,
+        1318
+      ],
+      [
+        141,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_02_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      44,
+      62
+    ],
+    "spriteSourceSize": [
+      44,
+      62
+    ],
+    "textureRect": [
+      [
+        4026,
+        3375
+      ],
+      [
+        44,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_02_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      9
+    ],
+    "spriteSize": [
+      20,
+      20
+    ],
+    "spriteSourceSize": [
+      24,
+      38
+    ],
+    "textureRect": [
+      [
+        143,
+        1296
+      ],
+      [
+        20,
+        20
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_02_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      70
+    ],
+    "spriteSourceSize": [
+      52,
+      70
+    ],
+    "textureRect": [
+      [
+        3177,
+        3025
+      ],
+      [
+        52,
+        70
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_02_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      74
+    ],
+    "spriteSourceSize": [
+      38,
+      74
+    ],
+    "textureRect": [
+      [
+        2848,
+        404
+      ],
+      [
+        38,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_02_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -9,
+      14
+    ],
+    "spriteSize": [
+      14,
+      26
+    ],
+    "spriteSourceSize": [
+      32,
+      54
+    ],
+    "textureRect": [
+      [
+        325,
+        543
+      ],
+      [
+        14,
+        26
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_02_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      47,
+      82
+    ],
+    "spriteSourceSize": [
+      47,
+      82
+    ],
+    "textureRect": [
+      [
+        1145,
+        1389
+      ],
+      [
+        47,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_02_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      55,
+      34
+    ],
+    "spriteSourceSize": [
+      55,
+      34
+    ],
+    "textureRect": [
+      [
+        444,
+        1510
+      ],
+      [
+        55,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_02_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_02_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      42
+    ],
+    "spriteSourceSize": [
+      63,
+      42
+    ],
+    "textureRect": [
+      [
+        2561,
+        1513
+      ],
+      [
+        63,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      5
+    ],
+    "spriteSize": [
+      107,
+      108
+    ],
+    "spriteSourceSize": [
+      121,
+      118
+    ],
+    "textureRect": [
+      [
+        914,
+        145
+      ],
+      [
+        107,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      21,
+      8
+    ],
+    "spriteSize": [
+      35,
+      34
+    ],
+    "spriteSourceSize": [
+      77,
+      50
+    ],
+    "textureRect": [
+      [
+        1084,
+        1993
+      ],
+      [
+        35,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      11,
+      24
+    ],
+    "spriteSize": [
+      89,
+      60
+    ],
+    "spriteSourceSize": [
+      111,
+      108
+    ],
+    "textureRect": [
+      [
+        2255,
+        2627
+      ],
+      [
+        89,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      5
+    ],
+    "spriteSize": [
+      115,
+      116
+    ],
+    "spriteSourceSize": [
+      129,
+      126
+    ],
+    "textureRect": [
+      [
+        524,
+        1878
+      ],
+      [
+        115,
+        116
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      44,
+      62
+    ],
+    "spriteSourceSize": [
+      44,
+      62
+    ],
+    "textureRect": [
+      [
+        4026,
+        3375
+      ],
+      [
+        44,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_03_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      9
+    ],
+    "spriteSize": [
+      20,
+      20
+    ],
+    "spriteSourceSize": [
+      24,
+      38
+    ],
+    "textureRect": [
+      [
+        143,
+        1296
+      ],
+      [
+        20,
+        20
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      70
+    ],
+    "spriteSourceSize": [
+      52,
+      70
+    ],
+    "textureRect": [
+      [
+        3177,
+        3025
+      ],
+      [
+        52,
+        70
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_03_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      74
+    ],
+    "spriteSourceSize": [
+      38,
+      74
+    ],
+    "textureRect": [
+      [
+        2848,
+        404
+      ],
+      [
+        38,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -9,
+      14
+    ],
+    "spriteSize": [
+      14,
+      26
+    ],
+    "spriteSourceSize": [
+      32,
+      54
+    ],
+    "textureRect": [
+      [
+        325,
+        543
+      ],
+      [
+        14,
+        26
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_03_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      47,
+      82
+    ],
+    "spriteSourceSize": [
+      47,
+      82
+    ],
+    "textureRect": [
+      [
+        1145,
+        1389
+      ],
+      [
+        47,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      55,
+      34
+    ],
+    "spriteSourceSize": [
+      55,
+      34
+    ],
+    "textureRect": [
+      [
+        444,
+        1510
+      ],
+      [
+        55,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_03_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      42
+    ],
+    "spriteSourceSize": [
+      63,
+      42
+    ],
+    "textureRect": [
+      [
+        2561,
+        1513
+      ],
+      [
+        63,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      120,
+      96
+    ],
+    "spriteSourceSize": [
+      120,
+      108
+    ],
+    "textureRect": [
+      [
+        157,
+        2659
+      ],
+      [
+        120,
+        96
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      25,
+      6
+    ],
+    "spriteSize": [
+      31,
+      34
+    ],
+    "spriteSourceSize": [
+      81,
+      46
+    ],
+    "textureRect": [
+      [
+        3526,
+        511
+      ],
+      [
+        31,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      26,
+      7
+    ],
+    "spriteSize": [
+      25,
+      28
+    ],
+    "spriteSourceSize": [
+      77,
+      42
+    ],
+    "textureRect": [
+      [
+        1668,
+        110
+      ],
+      [
+        25,
+        28
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      6
+    ],
+    "spriteSize": [
+      128,
+      104
+    ],
+    "spriteSourceSize": [
+      128,
+      116
+    ],
+    "textureRect": [
+      [
+        1868,
+        1651
+      ],
+      [
+        128,
+        104
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      42,
+      64
+    ],
+    "spriteSourceSize": [
+      48,
+      64
+    ],
+    "textureRect": [
+      [
+        3627,
+        3133
+      ],
+      [
+        42,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      52,
+      72
+    ],
+    "spriteSourceSize": [
+      58,
+      72
+    ],
+    "textureRect": [
+      [
+        3412,
+        3080
+      ],
+      [
+        52,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_04_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      50,
+      76
+    ],
+    "spriteSourceSize": [
+      50,
+      78
+    ],
+    "textureRect": [
+      [
+        3020,
+        3010
+      ],
+      [
+        50,
+        76
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_04_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -1
+    ],
+    "spriteSize": [
+      58,
+      86
+    ],
+    "spriteSourceSize": [
+      58,
+      88
+    ],
+    "textureRect": [
+      [
+        3680,
+        1849
+      ],
+      [
+        58,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      55,
+      34
+    ],
+    "spriteSourceSize": [
+      55,
+      34
+    ],
+    "textureRect": [
+      [
+        444,
+        1510
+      ],
+      [
+        55,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_04_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      42
+    ],
+    "spriteSourceSize": [
+      63,
+      42
+    ],
+    "textureRect": [
+      [
+        2561,
+        1513
+      ],
+      [
+        63,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_05_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      8
+    ],
+    "spriteSize": [
+      125,
+      108
+    ],
+    "spriteSourceSize": [
+      139,
+      124
+    ],
+    "textureRect": [
+      [
+        2751,
+        1661
+      ],
+      [
+        125,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_05_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      8
+    ],
+    "spriteSize": [
+      121,
+      104
+    ],
+    "spriteSourceSize": [
+      137,
+      120
+    ],
+    "textureRect": [
+      [
+        3043,
+        1855
+      ],
+      [
+        121,
+        104
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_05_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      35,
+      1
+    ],
+    "spriteSize": [
+      61,
+      66
+    ],
+    "spriteSourceSize": [
+      131,
+      68
+    ],
+    "textureRect": [
+      [
+        3495,
+        1945
+      ],
+      [
+        61,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_05_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      8
+    ],
+    "spriteSize": [
+      133,
+      116
+    ],
+    "spriteSourceSize": [
+      147,
+      132
+    ],
+    "textureRect": [
+      [
+        2753,
+        896
+      ],
+      [
+        133,
+        116
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_05_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      52,
+      64
+    ],
+    "spriteSourceSize": [
+      56,
+      64
+    ],
+    "textureRect": [
+      [
+        3850,
+        3118
+      ],
+      [
+        52,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_05_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      48,
+      60
+    ],
+    "spriteSourceSize": [
+      52,
+      60
+    ],
+    "textureRect": [
+      [
+        1842,
+        2749
+      ],
+      [
+        48,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_05_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      0
+    ],
+    "spriteSize": [
+      60,
+      70
+    ],
+    "spriteSourceSize": [
+      64,
+      70
+    ],
+    "textureRect": [
+      [
+        3414,
+        2962
+      ],
+      [
+        60,
+        70
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_05_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      -3
+    ],
+    "spriteSize": [
+      42,
+      76
+    ],
+    "spriteSourceSize": [
+      46,
+      82
+    ],
+    "textureRect": [
+      [
+        2863,
+        2943
+      ],
+      [
+        42,
+        76
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_05_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      -3
+    ],
+    "spriteSize": [
+      38,
+      72
+    ],
+    "spriteSourceSize": [
+      42,
+      78
+    ],
+    "textureRect": [
+      [
+        122,
+        1711
+      ],
+      [
+        38,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_05_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      -3
+    ],
+    "spriteSize": [
+      50,
+      84
+    ],
+    "spriteSourceSize": [
+      54,
+      90
+    ],
+    "textureRect": [
+      [
+        2786,
+        2777
+      ],
+      [
+        50,
+        84
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_05_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      55,
+      34
+    ],
+    "spriteSourceSize": [
+      55,
+      34
+    ],
+    "textureRect": [
+      [
+        444,
+        1510
+      ],
+      [
+        55,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_05_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_05_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      42
+    ],
+    "spriteSourceSize": [
+      63,
+      42
+    ],
+    "textureRect": [
+      [
+        2561,
+        1513
+      ],
+      [
+        63,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      0
+    ],
+    "spriteSize": [
+      127,
+      110
+    ],
+    "spriteSourceSize": [
+      141,
+      110
+    ],
+    "textureRect": [
+      [
+        1718,
+        1758
+      ],
+      [
+        127,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      9
+    ],
+    "spriteSize": [
+      123,
+      64
+    ],
+    "spriteSourceSize": [
+      137,
+      82
+    ],
+    "textureRect": [
+      [
+        3249,
+        1726
+      ],
+      [
+        123,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      32,
+      5
+    ],
+    "spriteSize": [
+      31,
+      32
+    ],
+    "spriteSourceSize": [
+      95,
+      42
+    ],
+    "textureRect": [
+      [
+        3526,
+        546
+      ],
+      [
+        31,
+        32
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      0
+    ],
+    "spriteSize": [
+      135,
+      118
+    ],
+    "spriteSourceSize": [
+      149,
+      118
+    ],
+    "textureRect": [
+      [
+        1667,
+        304
+      ],
+      [
+        135,
+        118
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      50,
+      64
+    ],
+    "spriteSourceSize": [
+      52,
+      64
+    ],
+    "textureRect": [
+      [
+        3915,
+        3063
+      ],
+      [
+        50,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      46,
+      60
+    ],
+    "spriteSourceSize": [
+      48,
+      60
+    ],
+    "textureRect": [
+      [
+        1618,
+        2821
+      ],
+      [
+        46,
+        60
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_06_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      58,
+      72
+    ],
+    "spriteSourceSize": [
+      60,
+      72
+    ],
+    "textureRect": [
+      [
+        3678,
+        2259
+      ],
+      [
+        58,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      50,
+      78
+    ],
+    "spriteSourceSize": [
+      52,
+      78
+    ],
+    "textureRect": [
+      [
+        3264,
+        2871
+      ],
+      [
+        50,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_06_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      46,
+      74
+    ],
+    "spriteSourceSize": [
+      48,
+      74
+    ],
+    "textureRect": [
+      [
+        3339,
+        2962
+      ],
+      [
+        46,
+        74
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_06_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      58,
+      86
+    ],
+    "spriteSourceSize": [
+      60,
+      86
+    ],
+    "textureRect": [
+      [
+        3679,
+        2012
+      ],
+      [
+        58,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      55,
+      34
+    ],
+    "spriteSourceSize": [
+      55,
+      34
+    ],
+    "textureRect": [
+      [
+        444,
+        1510
+      ],
+      [
+        55,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_06_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      42
+    ],
+    "spriteSourceSize": [
+      63,
+      42
+    ],
+    "textureRect": [
+      [
+        2561,
+        1513
+      ],
+      [
+        63,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      4
+    ],
+    "spriteSize": [
+      133,
+      106
+    ],
+    "spriteSourceSize": [
+      141,
+      114
+    ],
+    "textureRect": [
+      [
+        2753,
+        1013
+      ],
+      [
+        133,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      2
+    ],
+    "spriteSize": [
+      101,
+      70
+    ],
+    "spriteSourceSize": [
+      113,
+      74
+    ],
+    "textureRect": [
+      [
+        1843,
+        2613
+      ],
+      [
+        101,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      20,
+      13
+    ],
+    "spriteSize": [
+      75,
+      88
+    ],
+    "spriteSourceSize": [
+      115,
+      114
+    ],
+    "textureRect": [
+      [
+        646,
+        968
+      ],
+      [
+        75,
+        88
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      4
+    ],
+    "spriteSize": [
+      141,
+      114
+    ],
+    "spriteSourceSize": [
+      149,
+      122
+    ],
+    "textureRect": [
+      [
+        308,
+        1243
+      ],
+      [
+        141,
+        114
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      -3
+    ],
+    "spriteSize": [
+      40,
+      54
+    ],
+    "spriteSourceSize": [
+      54,
+      60
+    ],
+    "textureRect": [
+      [
+        1478,
+        2933
+      ],
+      [
+        40,
+        54
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_07_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -8,
+      -21
+    ],
+    "spriteSize": [
+      34,
+      14
+    ],
+    "spriteSourceSize": [
+      50,
+      56
+    ],
+    "textureRect": [
+      [
+        1306,
+        212
+      ],
+      [
+        34,
+        14
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_07_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      -2
+    ],
+    "spriteSize": [
+      48,
+      64
+    ],
+    "spriteSourceSize": [
+      62,
+      68
+    ],
+    "textureRect": [
+      [
+        4031,
+        3107
+      ],
+      [
+        48,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_07_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      -11
+    ],
+    "spriteSize": [
+      50,
+      60
+    ],
+    "spriteSourceSize": [
+      62,
+      82
+    ],
+    "textureRect": [
+      [
+        3912,
+        3252
+      ],
+      [
+        50,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      -26
+    ],
+    "spriteSize": [
+      34,
+      26
+    ],
+    "spriteSourceSize": [
+      36,
+      78
+    ],
+    "textureRect": [
+      [
+        3414,
+        1135
+      ],
+      [
+        34,
+        26
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      -11
+    ],
+    "spriteSize": [
+      58,
+      68
+    ],
+    "spriteSourceSize": [
+      70,
+      90
+    ],
+    "textureRect": [
+      [
+        3678,
+        2332
+      ],
+      [
+        58,
+        68
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -0.5,
+      0.5
+    ],
+    "spriteSize": [
+      3,
+      3
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        108
+      ],
+      [
+        3,
+        3
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -0.5,
+      0.5
+    ],
+    "spriteSize": [
+      3,
+      3
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        108
+      ],
+      [
+        3,
+        3
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_07_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -0.5,
+      0.5
+    ],
+    "spriteSize": [
+      3,
+      3
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        108
+      ],
+      [
+        3,
+        3
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_08_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      0
+    ],
+    "spriteSize": [
+      137,
+      94
+    ],
+    "spriteSourceSize": [
+      153,
+      94
+    ],
+    "textureRect": [
+      [
+        1974,
+        469
+      ],
+      [
+        137,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_08_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -23,
+      10
+    ],
+    "spriteSize": [
+      24,
+      48
+    ],
+    "spriteSourceSize": [
+      70,
+      68
+    ],
+    "textureRect": [
+      [
+        149,
+        557
+      ],
+      [
+        24,
+        48
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_08_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      42,
+      10
+    ],
+    "spriteSize": [
+      63,
+      22
+    ],
+    "spriteSourceSize": [
+      147,
+      42
+    ],
+    "textureRect": [
+      [
+        146,
+        968
+      ],
+      [
+        63,
+        22
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_08_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      8,
+      0
+    ],
+    "spriteSize": [
+      145,
+      102
+    ],
+    "spriteSourceSize": [
+      161,
+      102
+    ],
+    "textureRect": [
+      [
+        321,
+        621
+      ],
+      [
+        145,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_08_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      42,
+      64
+    ],
+    "spriteSourceSize": [
+      48,
+      64
+    ],
+    "textureRect": [
+      [
+        3966,
+        3244
+      ],
+      [
+        42,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_08_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      38,
+      60
+    ],
+    "spriteSourceSize": [
+      44,
+      60
+    ],
+    "textureRect": [
+      [
+        122,
+        1914
+      ],
+      [
+        38,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_08_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      52,
+      72
+    ],
+    "spriteSourceSize": [
+      58,
+      72
+    ],
+    "textureRect": [
+      [
+        3412,
+        3080
+      ],
+      [
+        52,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_08_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      39,
+      74
+    ],
+    "spriteSourceSize": [
+      41,
+      74
+    ],
+    "textureRect": [
+      [
+        2848,
+        171
+      ],
+      [
+        39,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_08_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      6,
+      4
+    ],
+    "spriteSourceSize": [
+      6,
+      4
+    ],
+    "textureRect": [
+      [
+        3558,
+        98
+      ],
+      [
+        6,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_08_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      47,
+      82
+    ],
+    "spriteSourceSize": [
+      49,
+      82
+    ],
+    "textureRect": [
+      [
+        3027,
+        2814
+      ],
+      [
+        47,
+        82
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_08_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      55,
+      34
+    ],
+    "spriteSourceSize": [
+      55,
+      34
+    ],
+    "textureRect": [
+      [
+        444,
+        1510
+      ],
+      [
+        55,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_08_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      50,
+      30
+    ],
+    "spriteSourceSize": [
+      50,
+      30
+    ],
+    "textureRect": [
+      [
+        473,
+        617
+      ],
+      [
+        50,
+        30
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_08_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      42
+    ],
+    "spriteSourceSize": [
+      63,
+      42
+    ],
+    "textureRect": [
+      [
+        2561,
+        1513
+      ],
+      [
+        63,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_09_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      11
+    ],
+    "spriteSize": [
+      135,
+      110
+    ],
+    "spriteSourceSize": [
+      143,
+      132
+    ],
+    "textureRect": [
+      [
+        1667,
+        423
+      ],
+      [
+        135,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_09_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      27,
+      17
+    ],
+    "spriteSize": [
+      85,
+      94
+    ],
+    "spriteSourceSize": [
+      139,
+      128
+    ],
+    "textureRect": [
+      [
+        1244,
+        1962
+      ],
+      [
+        85,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_09_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      35,
+      6
+    ],
+    "spriteSize": [
+      63,
+      40
+    ],
+    "spriteSourceSize": [
+      133,
+      52
+    ],
+    "textureRect": [
+      [
+        3002,
+        1768
+      ],
+      [
+        63,
+        40
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_09_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      11
+    ],
+    "spriteSize": [
+      143,
+      118
+    ],
+    "spriteSourceSize": [
+      151,
+      140
+    ],
+    "textureRect": [
+      [
+        2634,
+        764
+      ],
+      [
+        143,
+        118
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_09_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      42,
+      64
+    ],
+    "spriteSourceSize": [
+      48,
+      64
+    ],
+    "textureRect": [
+      [
+        3627,
+        3133
+      ],
+      [
+        42,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_09_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      38,
+      60
+    ],
+    "spriteSourceSize": [
+      44,
+      60
+    ],
+    "textureRect": [
+      [
+        122,
+        1914
+      ],
+      [
+        38,
+        60
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_09_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      0
+    ],
+    "spriteSize": [
+      52,
+      72
+    ],
+    "spriteSourceSize": [
+      58,
+      72
+    ],
+    "textureRect": [
+      [
+        3412,
+        3080
+      ],
+      [
+        52,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_09_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      39,
+      74
+    ],
+    "spriteSourceSize": [
+      41,
+      74
+    ],
+    "textureRect": [
+      [
+        2848,
+        171
+      ],
+      [
+        39,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_09_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      32,
+      66
+    ],
+    "spriteSourceSize": [
+      32,
+      66
+    ],
+    "textureRect": [
+      [
+        3012,
+        1374
+      ],
+      [
+        32,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_09_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      47,
+      82
+    ],
+    "spriteSourceSize": [
+      49,
+      82
+    ],
+    "textureRect": [
+      [
+        3027,
+        2814
+      ],
+      [
+        47,
+        82
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_09_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      55,
+      34
+    ],
+    "spriteSourceSize": [
+      55,
+      34
+    ],
+    "textureRect": [
+      [
+        444,
+        1510
+      ],
+      [
+        55,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_09_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      50,
+      30
+    ],
+    "spriteSourceSize": [
+      50,
+      30
+    ],
+    "textureRect": [
+      [
+        473,
+        617
+      ],
+      [
+        50,
+        30
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_09_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      42
+    ],
+    "spriteSourceSize": [
+      63,
+      42
+    ],
+    "textureRect": [
+      [
+        2561,
+        1513
+      ],
+      [
+        63,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_10_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      10,
+      8
+    ],
+    "spriteSize": [
+      141,
+      100
+    ],
+    "spriteSourceSize": [
+      161,
+      116
+    ],
+    "textureRect": [
+      [
+        3148,
+        874
+      ],
+      [
+        141,
+        100
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_10_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      22,
+      19
+    ],
+    "spriteSize": [
+      113,
+      74
+    ],
+    "spriteSourceSize": [
+      157,
+      112
+    ],
+    "textureRect": [
+      [
+        565,
+        1560
+      ],
+      [
+        113,
+        74
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_10_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      32,
+      0
+    ],
+    "spriteSize": [
+      47,
+      12
+    ],
+    "spriteSourceSize": [
+      111,
+      12
+    ],
+    "textureRect": [
+      [
+        4082,
+        1280
+      ],
+      [
+        47,
+        12
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_10_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      9,
+      7
+    ],
+    "spriteSize": [
+      149,
+      108
+    ],
+    "spriteSourceSize": [
+      167,
+      122
+    ],
+    "textureRect": [
+      [
+        3407,
+        1502
+      ],
+      [
+        149,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_10_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      48,
+      70
+    ],
+    "spriteSourceSize": [
+      50,
+      70
+    ],
+    "textureRect": [
+      [
+        3097,
+        3027
+      ],
+      [
+        48,
+        70
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_10_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      8
+    ],
+    "spriteSize": [
+      18,
+      26
+    ],
+    "spriteSourceSize": [
+      22,
+      42
+    ],
+    "textureRect": [
+      [
+        325,
+        524
+      ],
+      [
+        18,
+        26
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_10_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      56,
+      78
+    ],
+    "spriteSourceSize": [
+      58,
+      78
+    ],
+    "textureRect": [
+      [
+        2985,
+        2404
+      ],
+      [
+        56,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_10_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      1
+    ],
+    "spriteSize": [
+      50,
+      76
+    ],
+    "spriteSourceSize": [
+      52,
+      78
+    ],
+    "textureRect": [
+      [
+        2745,
+        2911
+      ],
+      [
+        50,
+        76
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_10_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -2,
+      10
+    ],
+    "spriteSize": [
+      20,
+      32
+    ],
+    "spriteSourceSize": [
+      24,
+      52
+    ],
+    "textureRect": [
+      [
+        873,
+        463
+      ],
+      [
+        20,
+        32
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_10_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      1
+    ],
+    "spriteSize": [
+      58,
+      84
+    ],
+    "spriteSourceSize": [
+      60,
+      86
+    ],
+    "textureRect": [
+      [
+        3678,
+        2099
+      ],
+      [
+        58,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_10_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      55,
+      34
+    ],
+    "spriteSourceSize": [
+      55,
+      34
+    ],
+    "textureRect": [
+      [
+        444,
+        1510
+      ],
+      [
+        55,
+        34
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_10_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      50,
+      30
+    ],
+    "spriteSourceSize": [
+      50,
+      30
+    ],
+    "textureRect": [
+      [
+        473,
+        617
+      ],
+      [
+        50,
+        30
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_10_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      63,
+      42
+    ],
+    "spriteSourceSize": [
+      63,
+      42
+    ],
+    "textureRect": [
+      [
+        2561,
+        1513
+      ],
+      [
+        63,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      5
+    ],
+    "spriteSize": [
+      128,
+      102
+    ],
+    "spriteSourceSize": [
+      136,
+      112
+    ],
+    "textureRect": [
+      [
+        1589,
+        1736
+      ],
+      [
+        128,
+        102
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      5,
+      4
+    ],
+    "spriteSize": [
+      122,
+      94
+    ],
+    "spriteSourceSize": [
+      132,
+      102
+    ],
+    "textureRect": [
+      [
+        3373,
+        1787
+      ],
+      [
+        122,
+        94
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      42,
+      6
+    ],
+    "spriteSize": [
+      38,
+      12
+    ],
+    "spriteSourceSize": [
+      122,
+      24
+    ],
+    "textureRect": [
+      [
+        4082,
+        1328
+      ],
+      [
+        38,
+        12
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_11_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      4,
+      5
+    ],
+    "spriteSize": [
+      138,
+      110
+    ],
+    "spriteSourceSize": [
+      146,
+      120
+    ],
+    "textureRect": [
+      [
+        1334,
+        1219
+      ],
+      [
+        138,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      44,
+      66
+    ],
+    "spriteSourceSize": [
+      44,
+      66
+    ],
+    "textureRect": [
+      [
+        2998,
+        1895
+      ],
+      [
+        44,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      38,
+      56
+    ],
+    "spriteSourceSize": [
+      38,
+      58
+    ],
+    "textureRect": [
+      [
+        122,
+        1975
+      ],
+      [
+        38,
+        56
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      74
+    ],
+    "spriteSourceSize": [
+      52,
+      74
+    ],
+    "textureRect": [
+      [
+        1062,
+        2657
+      ],
+      [
+        52,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      0
+    ],
+    "spriteSize": [
+      46,
+      76
+    ],
+    "spriteSourceSize": [
+      48,
+      76
+    ],
+    "textureRect": [
+      [
+        1146,
+        1312
+      ],
+      [
+        46,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      1
+    ],
+    "spriteSize": [
+      38,
+      64
+    ],
+    "spriteSourceSize": [
+      40,
+      66
+    ],
+    "textureRect": [
+      [
+        122,
+        1784
+      ],
+      [
+        38,
+        64
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      -1
+    ],
+    "spriteSize": [
+      54,
+      84
+    ],
+    "spriteSourceSize": [
+      56,
+      86
+    ],
+    "textureRect": [
+      [
+        2786,
+        2722
+      ],
+      [
+        54,
+        84
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_11_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      34
+    ],
+    "spriteSourceSize": [
+      56,
+      34
+    ],
+    "textureRect": [
+      [
+        122,
+        2734
+      ],
+      [
+        56,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_11_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_11_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      64,
+      42
+    ],
+    "spriteSourceSize": [
+      64,
+      42
+    ],
+    "textureRect": [
+      [
+        4031,
+        3242
+      ],
+      [
+        64,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_12_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      0
+    ],
+    "spriteSize": [
+      120,
+      100
+    ],
+    "spriteSourceSize": [
+      134,
+      100
+    ],
+    "textureRect": [
+      [
+        3148,
+        1280
+      ],
+      [
+        120,
+        100
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_12_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      9,
+      5
+    ],
+    "spriteSize": [
+      110,
+      70
+    ],
+    "spriteSourceSize": [
+      128,
+      80
+    ],
+    "textureRect": [
+      [
+        1554,
+        2457
+      ],
+      [
+        110,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_12_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      0
+    ],
+    "spriteSize": [
+      130,
+      108
+    ],
+    "spriteSourceSize": [
+      142,
+      108
+    ],
+    "textureRect": [
+      [
+        2013,
+        1482
+      ],
+      [
+        130,
+        108
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_12_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      44,
+      66
+    ],
+    "spriteSourceSize": [
+      44,
+      68
+    ],
+    "textureRect": [
+      [
+        2998,
+        1962
+      ],
+      [
+        44,
+        66
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_12_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_12_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      1
+    ],
+    "spriteSize": [
+      52,
+      74
+    ],
+    "spriteSourceSize": [
+      52,
+      76
+    ],
+    "textureRect": [
+      [
+        2387,
+        2463
+      ],
+      [
+        52,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_12_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      -1
+    ],
+    "spriteSize": [
+      42,
+      78
+    ],
+    "spriteSourceSize": [
+      48,
+      80
+    ],
+    "textureRect": [
+      [
+        1073,
+        2501
+      ],
+      [
+        42,
+        78
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_12_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_12_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -3,
+      -1
+    ],
+    "spriteSize": [
+      50,
+      86
+    ],
+    "spriteSourceSize": [
+      56,
+      88
+    ],
+    "textureRect": [
+      [
+        1641,
+        2770
+      ],
+      [
+        50,
+        86
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_12_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      34
+    ],
+    "spriteSourceSize": [
+      56,
+      34
+    ],
+    "textureRect": [
+      [
+        1084,
+        2277
+      ],
+      [
+        56,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_12_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_12_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      64,
+      42
+    ],
+    "spriteSourceSize": [
+      64,
+      42
+    ],
+    "textureRect": [
+      [
+        4031,
+        3242
+      ],
+      [
+        64,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_13_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      7
+    ],
+    "spriteSize": [
+      160,
+      110
+    ],
+    "spriteSourceSize": [
+      172,
+      124
+    ],
+    "textureRect": [
+      [
+        1197,
+        388
+      ],
+      [
+        160,
+        110
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_13_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      13,
+      -5
+    ],
+    "spriteSize": [
+      104,
+      76
+    ],
+    "spriteSourceSize": [
+      130,
+      86
+    ],
+    "textureRect": [
+      [
+        827,
+        2833
+      ],
+      [
+        104,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_13_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      26,
+      4
+    ],
+    "spriteSize": [
+      88,
+      46
+    ],
+    "spriteSourceSize": [
+      140,
+      54
+    ],
+    "textureRect": [
+      [
+        455,
+        1033
+      ],
+      [
+        88,
+        46
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_13_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      7
+    ],
+    "spriteSize": [
+      168,
+      118
+    ],
+    "spriteSourceSize": [
+      180,
+      132
+    ],
+    "textureRect": [
+      [
+        1357,
+        677
+      ],
+      [
+        168,
+        118
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_13_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      44,
+      62
+    ],
+    "spriteSourceSize": [
+      44,
+      62
+    ],
+    "textureRect": [
+      [
+        2036,
+        2718
+      ],
+      [
+        44,
+        62
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_13_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_13_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      70
+    ],
+    "spriteSourceSize": [
+      52,
+      70
+    ],
+    "textureRect": [
+      [
+        3177,
+        3025
+      ],
+      [
+        52,
+        70
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_13_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      74
+    ],
+    "spriteSourceSize": [
+      38,
+      74
+    ],
+    "textureRect": [
+      [
+        4056,
+        1406
+      ],
+      [
+        38,
+        74
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_13_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_13_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      48,
+      82
+    ],
+    "spriteSourceSize": [
+      48,
+      82
+    ],
+    "textureRect": [
+      [
+        2288,
+        2380
+      ],
+      [
+        48,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_13_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      34
+    ],
+    "spriteSourceSize": [
+      56,
+      34
+    ],
+    "textureRect": [
+      [
+        122,
+        2734
+      ],
+      [
+        56,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_13_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_13_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      64,
+      42
+    ],
+    "spriteSourceSize": [
+      64,
+      42
+    ],
+    "textureRect": [
+      [
+        4031,
+        3242
+      ],
+      [
+        64,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_14_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      20
+    ],
+    "spriteSize": [
+      144,
+      142
+    ],
+    "spriteSourceSize": [
+      146,
+      182
+    ],
+    "textureRect": [
+      [
+        3414,
+        1165
+      ],
+      [
+        144,
+        142
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_14_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      19
+    ],
+    "spriteSize": [
+      138,
+      130
+    ],
+    "spriteSourceSize": [
+      140,
+      168
+    ],
+    "textureRect": [
+      [
+        2326,
+        1084
+      ],
+      [
+        138,
+        130
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_14_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      1,
+      20
+    ],
+    "spriteSize": [
+      154,
+      150
+    ],
+    "spriteSourceSize": [
+      156,
+      190
+    ],
+    "textureRect": [
+      [
+        3744,
+        1077
+      ],
+      [
+        154,
+        150
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_14_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      44,
+      64
+    ],
+    "spriteSourceSize": [
+      44,
+      64
+    ],
+    "textureRect": [
+      [
+        3966,
+        3156
+      ],
+      [
+        44,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_14_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      38,
+      58
+    ],
+    "spriteSourceSize": [
+      38,
+      58
+    ],
+    "textureRect": [
+      [
+        3678,
+        2611
+      ],
+      [
+        38,
+        58
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_14_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      52,
+      74
+    ],
+    "spriteSourceSize": [
+      52,
+      74
+    ],
+    "textureRect": [
+      [
+        3343,
+        2909
+      ],
+      [
+        52,
+        74
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_14_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      -1
+    ],
+    "spriteSize": [
+      40,
+      84
+    ],
+    "spriteSourceSize": [
+      54,
+      86
+    ],
+    "textureRect": [
+      [
+        4054,
+        1610
+      ],
+      [
+        40,
+        84
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_14_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      0
+    ],
+    "spriteSize": [
+      34,
+      72
+    ],
+    "spriteSourceSize": [
+      48,
+      72
+    ],
+    "textureRect": [
+      [
+        1084,
+        2028
+      ],
+      [
+        34,
+        72
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_14_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -7,
+      0
+    ],
+    "spriteSize": [
+      48,
+      92
+    ],
+    "spriteSourceSize": [
+      62,
+      92
+    ],
+    "textureRect": [
+      [
+        2994,
+        2029
+      ],
+      [
+        48,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_14_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_14_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_14_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_15_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      118,
+      82
+    ],
+    "spriteSourceSize": [
+      124,
+      82
+    ],
+    "textureRect": [
+      [
+        401,
+        2649
+      ],
+      [
+        118,
+        82
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_15_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      6,
+      0
+    ],
+    "spriteSize": [
+      92,
+      76
+    ],
+    "spriteSourceSize": [
+      104,
+      76
+    ],
+    "textureRect": [
+      [
+        2543,
+        2504
+      ],
+      [
+        92,
+        76
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_15_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      13,
+      9
+    ],
+    "spriteSize": [
+      52,
+      32
+    ],
+    "spriteSourceSize": [
+      78,
+      50
+    ],
+    "textureRect": [
+      [
+        114,
+        3007
+      ],
+      [
+        52,
+        32
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_15_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      3,
+      0
+    ],
+    "spriteSize": [
+      126,
+      90
+    ],
+    "spriteSourceSize": [
+      132,
+      90
+    ],
+    "textureRect": [
+      [
+        2753,
+        1570
+      ],
+      [
+        126,
+        90
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_15_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      42,
+      64
+    ],
+    "spriteSourceSize": [
+      42,
+      68
+    ],
+    "textureRect": [
+      [
+        4031,
+        3285
+      ],
+      [
+        42,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_15_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      -6
+    ],
+    "spriteSize": [
+      32,
+      40
+    ],
+    "spriteSourceSize": [
+      32,
+      52
+    ],
+    "textureRect": [
+      [
+        2179,
+        2221
+      ],
+      [
+        32,
+        40
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_15_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      2
+    ],
+    "spriteSize": [
+      50,
+      72
+    ],
+    "spriteSourceSize": [
+      50,
+      76
+    ],
+    "textureRect": [
+      [
+        3554,
+        3111
+      ],
+      [
+        50,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_15_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      2
+    ],
+    "spriteSize": [
+      42,
+      74
+    ],
+    "spriteSourceSize": [
+      54,
+      78
+    ],
+    "textureRect": [
+      [
+        3264,
+        2973
+      ],
+      [
+        42,
+        74
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_15_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      -8
+    ],
+    "spriteSize": [
+      32,
+      44
+    ],
+    "spriteSourceSize": [
+      40,
+      60
+    ],
+    "textureRect": [
+      [
+        2179,
+        2176
+      ],
+      [
+        32,
+        44
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_15_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -6,
+      2
+    ],
+    "spriteSize": [
+      50,
+      82
+    ],
+    "spriteSourceSize": [
+      62,
+      86
+    ],
+    "textureRect": [
+      [
+        2579,
+        2846
+      ],
+      [
+        50,
+        82
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_15_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      34
+    ],
+    "spriteSourceSize": [
+      56,
+      34
+    ],
+    "textureRect": [
+      [
+        1084,
+        2277
+      ],
+      [
+        56,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_15_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_15_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      64,
+      42
+    ],
+    "spriteSourceSize": [
+      64,
+      42
+    ],
+    "textureRect": [
+      [
+        4031,
+        3242
+      ],
+      [
+        64,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_16_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      16,
+      17
+    ],
+    "spriteSize": [
+      98,
+      128
+    ],
+    "spriteSourceSize": [
+      130,
+      162
+    ],
+    "textureRect": [
+      [
+        2273,
+        1602
+      ],
+      [
+        98,
+        128
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_16_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      27,
+      -8
+    ],
+    "spriteSize": [
+      64,
+      48
+    ],
+    "spriteSourceSize": [
+      118,
+      64
+    ],
+    "textureRect": [
+      [
+        3731,
+        3154
+      ],
+      [
+        64,
+        48
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_16_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      31,
+      9
+    ],
+    "spriteSize": [
+      38,
+      12
+    ],
+    "spriteSourceSize": [
+      100,
+      30
+    ],
+    "textureRect": [
+      [
+        4082,
+        1367
+      ],
+      [
+        38,
+        12
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_16_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      15,
+      17
+    ],
+    "spriteSize": [
+      108,
+      136
+    ],
+    "spriteSourceSize": [
+      138,
+      170
+    ],
+    "textureRect": [
+      [
+        1473,
+        1319
+      ],
+      [
+        108,
+        136
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_16_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      1
+    ],
+    "spriteSize": [
+      46,
+      68
+    ],
+    "spriteSourceSize": [
+      56,
+      70
+    ],
+    "textureRect": [
+      [
+        3485,
+        3061
+      ],
+      [
+        46,
+        68
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_16_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      -14
+    ],
+    "spriteSize": [
+      38,
+      30
+    ],
+    "spriteSourceSize": [
+      48,
+      58
+    ],
+    "textureRect": [
+      [
+        3861,
+        1781
+      ],
+      [
+        38,
+        30
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_16_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      1
+    ],
+    "spriteSize": [
+      54,
+      76
+    ],
+    "spriteSourceSize": [
+      64,
+      78
+    ],
+    "textureRect": [
+      [
+        3100,
+        2972
+      ],
+      [
+        54,
+        76
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_16_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      -1
+    ],
+    "spriteSize": [
+      46,
+      80
+    ],
+    "spriteSourceSize": [
+      56,
+      82
+    ],
+    "textureRect": [
+      [
+        1146,
+        1231
+      ],
+      [
+        46,
+        80
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_16_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -4,
+      -19
+    ],
+    "spriteSize": [
+      38,
+      36
+    ],
+    "spriteSourceSize": [
+      46,
+      74
+    ],
+    "textureRect": [
+      [
+        1084,
+        1852
+      ],
+      [
+        38,
+        36
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_16_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -5,
+      -1
+    ],
+    "spriteSize": [
+      54,
+      88
+    ],
+    "spriteSourceSize": [
+      64,
+      90
+    ],
+    "textureRect": [
+      [
+        2146,
+        2663
+      ],
+      [
+        54,
+        88
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_16_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      34
+    ],
+    "spriteSourceSize": [
+      56,
+      34
+    ],
+    "textureRect": [
+      [
+        1082,
+        2334
+      ],
+      [
+        56,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_16_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_16_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      64,
+      42
+    ],
+    "spriteSourceSize": [
+      64,
+      42
+    ],
+    "textureRect": [
+      [
+        4031,
+        3242
+      ],
+      [
+        64,
+        42
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_17_01_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      5
+    ],
+    "spriteSize": [
+      140,
+      98
+    ],
+    "spriteSourceSize": [
+      154,
+      108
+    ],
+    "textureRect": [
+      [
+        1193,
+        1217
+      ],
+      [
+        140,
+        98
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_17_01_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      5
+    ],
+    "spriteSize": [
+      134,
+      92
+    ],
+    "spriteSourceSize": [
+      148,
+      102
+    ],
+    "textureRect": [
+      [
+        1610,
+        1343
+      ],
+      [
+        134,
+        92
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_17_01_extra_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      43,
+      10
+    ],
+    "spriteSize": [
+      54,
+      12
+    ],
+    "spriteSourceSize": [
+      140,
+      32
+    ],
+    "textureRect": [
+      [
+        4083,
+        1175
+      ],
+      [
+        54,
+        12
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_17_01_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      7,
+      5
+    ],
+    "spriteSize": [
+      148,
+      106
+    ],
+    "spriteSourceSize": [
+      162,
+      116
+    ],
+    "textureRect": [
+      [
+        3408,
+        1310
+      ],
+      [
+        148,
+        106
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_17_02_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      48,
+      64
+    ],
+    "spriteSourceSize": [
+      50,
+      64
+    ],
+    "textureRect": [
+      [
+        3731,
+        3203
+      ],
+      [
+        48,
+        64
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_17_02_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      42,
+      58
+    ],
+    "spriteSourceSize": [
+      44,
+      58
+    ],
+    "textureRect": [
+      [
+        3678,
+        2568
+      ],
+      [
+        42,
+        58
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_17_02_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      -1,
+      0
+    ],
+    "spriteSize": [
+      56,
+      72
+    ],
+    "spriteSourceSize": [
+      58,
+      72
+    ],
+    "textureRect": [
+      [
+        3554,
+        3054
+      ],
+      [
+        56,
+        72
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_17_03_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      48,
+      78
+    ],
+    "spriteSourceSize": [
+      48,
+      78
+    ],
+    "textureRect": [
+      [
+        3106,
+        2923
+      ],
+      [
+        48,
+        78
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_17_03_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      42,
+      70
+    ],
+    "spriteSourceSize": [
+      42,
+      70
+    ],
+    "textureRect": [
+      [
+        3628,
+        2991
+      ],
+      [
+        42,
+        70
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_17_03_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      86
+    ],
+    "spriteSourceSize": [
+      56,
+      86
+    ],
+    "textureRect": [
+      [
+        3676,
+        2782
+      ],
+      [
+        56,
+        86
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_17_04_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      56,
+      34
+    ],
+    "spriteSourceSize": [
+      56,
+      34
+    ],
+    "textureRect": [
+      [
+        1084,
+        2277
+      ],
+      [
+        56,
+        34
+      ]
+    ],
+    "textureRotated": true
+  },
+  "spider_17_04_2_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      4,
+      4
+    ],
+    "spriteSourceSize": [
+      4,
+      4
+    ],
+    "textureRect": [
+      [
+        3563,
+        103
+      ],
+      [
+        4,
+        4
+      ]
+    ],
+    "textureRotated": false
+  },
+  "spider_17_04_glow_001.png": {
+    "aliases": [],
+    "spriteOffset": [
+      0,
+      0
+    ],
+    "spriteSize": [
+      64,
+      42
+    ],
+    "spriteSourceSize": [
+      64,
+      42
+    ],
+    "textureRect": [
+      [
+        4031,
+        3242
+      ],
+      [
+        64,
+        42
+      ]
+    ],
+    "textureRotated": false
+  }
+}

--- a/icons/parsePlist.js
+++ b/icons/parsePlist.js
@@ -1,0 +1,12 @@
+const plist = require('plist');
+const { readFileSync, writeFileSync } = require('fs');
+const data = plist.parse(readFileSync('./GJ_GameSheet02-uhd.plist', 'utf8'));
+for (let key in data.frames) {
+  let fileData = data.frames[key];
+  for (let innerKey in fileData) {
+    if (typeof fileData[innerKey] === 'string') {
+      fileData[innerKey] = JSON.parse(fileData[innerKey].replace(/{/g, '[').replace(/}/g, ']'));
+    }
+  }
+}
+writeFileSync('./gameSheet.json', JSON.stringify(data.frames, null, 2));


### PR DESCRIPTION
I've made many major improvements to `icon.js`. 

First off, I've created `parsePlist.js` to convert the `.plist` file containing metadata about the images into a JSON file for easier use in `icon.js`. `parsePlist.js` should be run before using the server; it saves the file to the filesystem, and `icon.js` imports that generated JSON file. No more super-long chains of `.map`, `.slice`, and `.trim`!

Secondly, I improved the query parsing by making it more terse. It uses a "query mapper" to more effectively generate the necessary options.

Next, I added `fromIcons`, `genFileName`, and `genImageName` functions to make creating paths and reading from those paths take less lines of code while being more readable.

I removed the `ufoMode`, `robotMode`, and `spiderMode` booleans, replacing them with simple comparisons to the `form` of the icon.

I made the code size for generating the robot legs and glows INCREDIBLY tiny compared to before.

I'm planning on continuing to improve `icon.js`, especially in the actual image recoloring part, but I'm going to make a PR for that later so that the project can better isolate changes.

I hope you don't close this PR since I spent quite a while making these changes :( If you're confused or worried about any part, please don't hesitate to ask me or commit to my fork instead of rejecting the PR immediately.