### PR TITLE
Fixed extra not being added

### DIFF
--- a/api/icon.js
+++ b/api/icon.js
@@ -153,12 +153,12 @@ module.exports = async (app, req, res) => {
 
       res.contentType('image/png');
       let extrabit, offset2, size2;
-      if (fs.existsSync(extra)) {
+      if (fs.existsSync(fromIcons(extra))) {
         extrabit = icons[extra]
         offset2 = extrabit.spriteOffset.map(minusOrigOffset);
         size2 = extrabit.spriteSize;
 
-        extra = new Jimp(extra);
+        extra = new Jimp(fromIcons(extra));
         useExtra = true
       }
 


### PR DESCRIPTION
Super simple PR, I forgot to use `fromIcons` with the `extra` stuff, so `extra` never got added on top of the original icon and icons looked very weird as a result.
(Also, since you offered to add me to the contributors page, my IGN is "genius991")