### PR TITLE
Made it so you don't have to go back 2 times after "donwloading" a level

### DIFF
--- a/assets/sizecheck.js
+++ b/assets/sizecheck.js
@@ -22,7 +22,10 @@ $(window).resize(function () {
 }); 
 
 function backButton() {
-	if (window.history.length > 1 && document.referrer.startsWith(window.location.origin)) window.history.back()
+	if (window.history.length > 1 && document.referrer.startsWith(window.location.origin)){
+            if (window.location.href.endsWith('?download')) return window.history.go(-2);
+            window.history.back()
+        }
 	else window.location.href = "../../../../../"
 }
 

--- a/assets/sizecheck.js
+++ b/assets/sizecheck.js
@@ -23,7 +23,7 @@ $(window).resize(function () {
 
 function backButton() {
 	if (window.history.length > 1 && document.referrer.startsWith(window.location.origin)){
-            if (window.location.href.endsWith('?download')) window.history.go(-2);
+            if (window.location.href.endsWith('?download') && sessionStorage.getItem('prevUrl') === window.location.href.replace('?download', '')) window.history.go(-2);
             else window.history.back()
         }
 	else window.location.href = "../../../../../"

--- a/assets/sizecheck.js
+++ b/assets/sizecheck.js
@@ -22,6 +22,7 @@ $(window).resize(function () {
 });
 
 function saveUrl() {
+        if (window.location.href.endsWith('?download')) return;
 	sessionStorage.setItem('prevUrl', window.location.href);
 }
 

--- a/assets/sizecheck.js
+++ b/assets/sizecheck.js
@@ -23,8 +23,8 @@ $(window).resize(function () {
 
 function backButton() {
 	if (window.history.length > 1 && document.referrer.startsWith(window.location.origin)){
-            if (window.location.href.endsWith('?download')) return window.history.go(-2);
-            window.history.back()
+            if (window.location.href.endsWith('?download')) window.history.go(-2);
+            else window.history.back()
         }
 	else window.location.href = "../../../../../"
 }

--- a/assets/sizecheck.js
+++ b/assets/sizecheck.js
@@ -19,7 +19,11 @@ $(window).resize(function () {
 		$('#everything').show(); 
 		$('#tooSmall').hide() 
 	}
-}); 
+});
+
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 function backButton() {
 	if (window.history.length > 1 && document.referrer.startsWith(window.location.origin)){

--- a/html/analyze.html
+++ b/html/analyze.html
@@ -185,8 +185,4 @@ appendPortals()
 
 });
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
-
 </script>

--- a/html/analyze.html
+++ b/html/analyze.html
@@ -10,7 +10,7 @@
 	<link rel="icon" href="../assets/cp.png">
 </head>
 
-<body class="levelBG" style="overflow-y:auto;">
+<body class="levelBG" style="overflow-y:auto;" onbeforeunload="saveUrl()">
 
 <div id="everything" class="center">
 
@@ -183,9 +183,10 @@ appendPortals()
 	$('#loadingDiv').hide()
 	$('#analysisDiv').show()
 
-})
+});
 
-
-
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 </script>

--- a/html/api.html
+++ b/html/api.html
@@ -12,7 +12,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
-<body>
+<body onbeforeunload="saveUrl()">
 	<div class="main-header-wrap">
 		<div class="main-header">
 			<div class="header-links">
@@ -494,5 +494,9 @@
 			});
 		});
 	});
+
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 </script>

--- a/html/api.html
+++ b/html/api.html
@@ -495,8 +495,4 @@
 		});
 	});
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
-
 </script>

--- a/html/comments.html
+++ b/html/comments.html
@@ -9,7 +9,7 @@
 	<meta id="meta-image" name="og:image" itemprop="image" content="https://gdbrowser.com/assets/like.png">
 </head>
 
-<body class="levelBG">
+<body class="levelBG" onbeforeunload="saveUrl()">
 
 <div id="everything">
 	
@@ -183,8 +183,10 @@ $('#refresh').click(function() {
 	appendComments()
 })
 
-})
+});
 
-
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 </script>
 

--- a/html/comments.html
+++ b/html/comments.html
@@ -185,8 +185,5 @@ $('#refresh').click(function() {
 
 });
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
 </script>
 

--- a/html/filters.html
+++ b/html/filters.html
@@ -192,8 +192,6 @@ $(document).keydown(function(k) {
 	if (k.which == 13 && $('#filters').is(':hidden')) $('#searchBtn').trigger('click') //enter
 });
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
+
 
 </script>

--- a/html/filters.html
+++ b/html/filters.html
@@ -9,7 +9,7 @@
 	<meta id="meta-image" name="og:image" itemprop="image" content="https://gdbrowser.com/assets/coin.png">
 </head>
 
-<body class="levelBG">
+<body class="levelBG" onbeforeunload="saveUrl()">
 
 <div id="everything">
 
@@ -190,6 +190,10 @@ $('.lengthDiv').click(function() {
 
 $(document).keydown(function(k) {
 	if (k.which == 13 && $('#filters').is(':hidden')) $('#searchBtn').trigger('click') //enter
-})
+});
+
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 </script>

--- a/html/gauntlets.html
+++ b/html/gauntlets.html
@@ -44,8 +44,5 @@ $('#gauntletList').append(`
 			<h3 class="gauntletText"">${x}<br>Gauntlet</h3></div></a>`)
 })
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
 
 </script>

--- a/html/gauntlets.html
+++ b/html/gauntlets.html
@@ -9,7 +9,7 @@
 	<meta id="meta-image" name="og:image" itemprop="image" content="https://gdbrowser.com/assets/gauntlet.png">
 </head>
 
-<body class="levelBG darkBG" style="overflow-y:auto;">
+<body class="levelBG darkBG" style="overflow-y:auto;" onbeforeunload="saveUrl()">
 
 <div id="everything" class="center" style="width: 100%; height: 100%;">
 
@@ -44,6 +44,8 @@ $('#gauntletList').append(`
 			<h3 class="gauntletText"">${x}<br>Gauntlet</h3></div></a>`)
 })
 
-
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 </script>

--- a/html/home.html
+++ b/html/home.html
@@ -132,8 +132,4 @@ fetch(`./api/credits`).then(res => res.json()).then(res => {
 });
 });
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
-
 </script>

--- a/html/home.html
+++ b/html/home.html
@@ -9,7 +9,7 @@
 	<meta id="meta-image" name="og:image" itemprop="image" content="https://gdbrowser.com/assets/coin.png">
 </head>
 
-<body class="levelBG">
+<body class="levelBG" onbeforeunload="saveUrl()">
 
 <div id="everything">
 
@@ -130,6 +130,10 @@ fetch(`./api/credits`).then(res => res.json()).then(res => {
 	}
 	
 });
-})
+});
+
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 </script>

--- a/html/iconkit.html
+++ b/html/iconkit.html
@@ -11,7 +11,7 @@
     <link rel="icon" href="../assets/icon.png">
     </link>
 </head>
-<body class="iconscroll" style="background-image: linear-gradient(rgb(139, 139, 139), rgb(100, 100, 100));">
+<body class="iconscroll" style="background-image: linear-gradient(rgb(139, 139, 139), rgb(100, 100, 100));" onbeforeunload="saveUrl()">
 <div class="center hidden"><br>
     <img id="iconkitlogo" src="../assets/iconkit.png" height=50px; style="margin: 7px 0;"><br><br>
     <img id="loading" src="../assets/loading.png" class="spin" height=95px; style="margin: auto auto 25px auto">
@@ -225,5 +225,9 @@ $(document).keydown(function(k) {
 		$('#backButton').trigger('click')
 	}
 });
+
+function saveUrl() {
+    sessionStorage.setItem('prevUrl', window.location.href);
+}
     
 </script>

--- a/html/leaderboard.html
+++ b/html/leaderboard.html
@@ -172,8 +172,5 @@ function leaderboard() {
 		infoText(creatorText)
 	});
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
 
 </script>

--- a/html/leaderboard.html
+++ b/html/leaderboard.html
@@ -9,7 +9,7 @@
 	<meta id="meta-image" name="og:image" itemprop="image" content="https://gdbrowser.com/assets/trophy.png">
 </head>
 
-<body class="levelBG">
+<body class="levelBG" onbeforeunload="saveUrl()">
 
 <div id="everything" style="overflow: auto;">
 
@@ -170,6 +170,10 @@ function leaderboard() {
 		$('#accurateTabOff').show()
 		$('#creatorTabOn').show()
 		infoText(creatorText)
-	})
+	});
+
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 </script>

--- a/html/level.html
+++ b/html/level.html
@@ -233,8 +233,4 @@ function deleteLevel() {
 	freeze = true;
 }
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
-
 </script>

--- a/html/level.html
+++ b/html/level.html
@@ -9,7 +9,7 @@
 	<meta id="meta-image" name="og:image" itemprop="image" content="https://gdbrowser.com/difficulty/[[DIFFICULTYFACE]].png">
 </head>
 
-<body class="levelBG">
+<body class="levelBG" onbeforeunload="saveUrl()">
 
 <div id="everything">
 
@@ -231,6 +231,10 @@ function deleteLevel() {
 	document.cookie = `saved=${levelList.filter(x => x != "[[ID]]")}; expires=Fri, 31 Dec 9999 23:59:59 GMT`;
 	location.reload()
 	freeze = true;
+}
+
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
 }
 
 </script>

--- a/html/mappacks.html
+++ b/html/mappacks.html
@@ -44,8 +44,4 @@ fetch('../api/mappacks').then(res => res.json()).then(packs => {
 	})
 });
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
-
 </script>

--- a/html/mappacks.html
+++ b/html/mappacks.html
@@ -9,7 +9,7 @@
 	<meta id="meta-image" name="og:image" itemprop="image" content="https://gdbrowser.com/assets/folder.png">
 </head>
 
-<body class="levelBG" style="overflow-y:auto;">
+<body class="levelBG" style="overflow-y:auto;" onbeforeunload="saveUrl()">
 
 <div id="everything" class="center">
 
@@ -42,8 +42,10 @@ fetch('../api/mappacks').then(res => res.json()).then(packs => {
 			<img src="../difficulty/${packs[x][3]}.png" height="220%"><br>
 			<h3 class="gauntletText"">${x.replace("Pack", "<br>Pack")}</h3></div></a>`)
 	})
-})
+});
 
-
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 </script>

--- a/html/profile.html
+++ b/html/profile.html
@@ -9,7 +9,7 @@
 	<meta id="meta-image" name="og:image" itemprop="image" content="https://gdbrowser.com/icon/[[USERNAME]]">
 </head>
 
-<body class="levelBG">
+<body class="levelBG" onbeforeunload="saveUrl()">
 
 <div id="everything">
 	
@@ -186,6 +186,10 @@ loadingComments = false;
 let page = 0
 let loadingComments = false
 appendComments()
+
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 </script>
 

--- a/html/profile.html
+++ b/html/profile.html
@@ -187,9 +187,6 @@ let page = 0
 let loadingComments = false
 appendComments()
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
 
 </script>
 

--- a/html/search.html
+++ b/html/search.html
@@ -9,7 +9,7 @@
 	<meta id="meta-image" name="og:image" itemprop="image" content="https://gdbrowser.com/assets/coin.png">
 </head>
 
-<body class="levelBG">
+<body class="levelBG" onbeforeunload="saveUrl()">
 
 <div id="everything" style="overflow: auto;">
 
@@ -240,5 +240,9 @@ $(document).keydown(function(k) {
 		$('#pageUp').trigger('click')
     }
 });
+
+function saveUrl() {
+	sessionStorage.setItem('prevUrl', window.location.href);
+}
 
 </script>

--- a/html/search.html
+++ b/html/search.html
@@ -241,8 +241,4 @@ $(document).keydown(function(k) {
     }
 });
 
-function saveUrl() {
-	sessionStorage.setItem('prevUrl', window.location.href);
-}
-
 </script>


### PR DESCRIPTION
When you "download" a level, you have to go back 2 times to get to where you were (for example search results). I added one line to prevent that. I tried finding a way to do that for the internet browser back button, but couldn't figure out anything. If I find anything I'll make commit to this fork.