### PR TITLE
Removed jQuery

### DIFF
--- a/api/icon.js
+++ b/api/icon.js
@@ -37,11 +37,7 @@ module.exports = async (app, req, res) => {
       secret: 'Wmfd2893gb7'
     }
   }, function (err1, res1, body1) {
-    let response = body1.split('#')[0].split(':');
-    let result = {};
-    for (let i = 0; i < response.length; i += 2) {
-      result[response[i]] = response[i + 1]
-    }
+    let result = app.parseResponse(body1);
 
     request.post('http://boomlings.com/database/getGJUserInfo20.php', {
       form: {
@@ -50,11 +46,7 @@ module.exports = async (app, req, res) => {
       }
     }, function (err2, res2, body2) {
 
-      let response2 = body2 == "-1" ? '' : body2.split('#')[0].split(':');
-      let account = {};
-      for (let i = 0; i < response2.length; i += 2) {
-        account[response2[i]] = response2[i + 1]
-      }
+      let account = app.parseResponse(body2);
 
       let { form, ind } = forms[req.query.form] || {};
       form = form || 'player';

--- a/assets/css/api.css
+++ b/assets/css/api.css
@@ -81,11 +81,11 @@ quote{
 }
 
 .reveal {
-    color: #3994db;
+  color: #3994db;
 	cursor: pointer;
 	margin: 5px 0;
+	transition: height 100ms ease-in-out;
 }
-
 .reveal::after{
 	content: '';
 	display: inline-block;
@@ -101,15 +101,16 @@ quote{
 }
 
 .subdiv {
-    display: none;
-    padding: 5px 15px;
+	padding: 5px 15px;
 	background: rgba(166, 216, 255, 0.2);
 	border: 2px solid #3994db;
 	border-radius: 2px;
-    margin: 10px 0px 4px 0px;
-    line-height: 24px;
+	margin: 10px 0px 4px 0px;
+	line-height: 24px;
+	visibility: hidden;
+	transform: scaleY(0);
+	height: 0;
 }
-
 .indent {
     margin-left: 20px;
 }

--- a/assets/css/level.css
+++ b/assets/css/level.css
@@ -406,6 +406,17 @@ input::-webkit-inner-spin-button {
     cursor: pointer;
 }
 
+#copied {
+  transition: opacity 500ms ease-in-out;
+  opacity: 0;
+  visibility: hidden;
+}
+#copied.transitioning {
+  transition: opacity 200ms ease-in-out;
+  opacity: 1;
+  visibility: visible;
+}
+
 .menuButton:active {
     transition-duration: 0.05s;
     transition-timing-function: ease-in-out;

--- a/assets/css/level.css
+++ b/assets/css/level.css
@@ -400,7 +400,8 @@ input::-webkit-inner-spin-button {
 }
 
 .menuButton {
-    width: 24vh;
+    width: 20vw;
+    max-width: 24vh;
     margin: 1.2vh 2vh;
     cursor: pointer;
 }

--- a/assets/sizecheck.js
+++ b/assets/sizecheck.js
@@ -1,15 +1,15 @@
 document.body.insertAdjacentHTML('beforeEnd', `
 	<div id="tooSmall" class="brownbox center supercenter" style="display: none; width: 80%">
 	<h1>Yikes!</h1>
-	<p>Your <font color="#4CDA5B">screen</font> isn't <font color="aqua">wide</font> enough to <font color="yellow">display</font> this <font color="#4CDA5B">page</font>.<br>
-	Please <font color="yellow">rotate</font> your <font color="#4CDA5B">device</font> <font color="aqua">horizontally</font> or <font color="yellow">resize</font> your <font color="#4CDA5B">window</font> to be <font color="aqua">longer</font>.
+	<p>Your <span style="color:#4CDA5B">screen</span> isn't <span style="color:aqua">wide</span> enough to <span style="color:yellow">display</span> this <span style="color:#4CDA5B">page</span>.<br>
+	Please <span style="color:yellow">rotate</span> your <span style="color:#4CDA5B">device</span> <span style="color:aqua">horizontally</span> or <span style="color:yellow">resize</span> your <span style="color:#4CDA5B">window</span> to be <span style="color:aqua">longer</span>.
 	</p>
 	<p style="font-size: 1.8vh">Did I color too many words? I think I colored too many words.</p>
 	</div>
 `)
 
 const onResize = function () {
-	if (window.innerHeight > window.innerWidth) { 
+	if (window.innerHeight > window.innerWidth * 0.8) { 
 		document.querySelector('#everything').style.display = "none"; 
 		document.querySelector('#tooSmall').style.display = "block"; 
 	}	else { 

--- a/assets/sizecheck.js
+++ b/assets/sizecheck.js
@@ -1,4 +1,4 @@
-$('body').append(`
+document.body.insertAdjacentHTML('beforeEnd', `
 	<div id="tooSmall" class="brownbox center supercenter" style="display: none; width: 80%">
 	<h1>Yikes!</h1>
 	<p>Your <font color="#4CDA5B">screen</font> isn't <font color="aqua">wide</font> enough to <font color="yellow">display</font> this <font color="#4CDA5B">page</font>.<br>
@@ -8,36 +8,36 @@ $('body').append(`
 	</div>
 `)
 
-
-$(window).resize(function () {
-	if (window.innerHeight > window.innerWidth - 75) { 
-		$('#everything').hide(); 
-		$('#tooSmall').show();
+const onResize = function () {
+	if (window.innerHeight > window.innerWidth) { 
+		document.querySelector('#everything').style.display = "none"; 
+		document.querySelector('#tooSmall').style.display = "block"; 
+	}	else { 
+		document.querySelector('#everything').style.display = "block"; 
+		document.querySelector('#tooSmall').style.display = "none"; 
 	}
-
-	else { 
-		$('#everything').show(); 
-		$('#tooSmall').hide() 
-	}
-}); 
+};
+window.addEventListener('resize', onResize, {passive: true});
+onResize();
 
 function backButton() {
 	if (window.history.length > 1 && document.referrer.startsWith(window.location.origin)) window.history.back()
 	else window.location.href = "../../../../../"
 }
 
-$(document).keydown(function(k) {
-	if (k.keyCode == 27) { //esc
-		k.preventDefault()
-		if ($('.popup').is(":visible")) $('.popup').hide();   
-		else $('#backButton').trigger('click')
+document.addEventListener('keydown', function(k) {
+	if (k.code == "Escape") { //esc
+		k.preventDefault();
+		let found = false;
+		for (let el of document.querySelectorAll('.popup')) {
+			if (el.style.display != "none") {
+				el.style.display = "none";
+				found = true;
+				break;
+			};
+		}   
+		if (!found) document.querySelector('#backButton').click();
 	}
 });
 
-while ($(this).scrollTop() != 0) {
-	$(this).scrollTop(0);
-} 
-
-$(document).ready(function() {
-	$(window).trigger('resize');
-});
+document.body.scrollTop = 0;

--- a/assets/sizecheck.js
+++ b/assets/sizecheck.js
@@ -11,9 +11,9 @@ document.body.insertAdjacentHTML('beforeEnd', `
 const onResize = function () {
 	if (window.innerHeight > window.innerWidth * 0.8) { 
 		document.querySelector('#everything').style.display = "none"; 
-		document.querySelector('#tooSmall').style.display = "block"; 
+		document.querySelector('#tooSmall').style.display = 'block'; 
 	}	else { 
-		document.querySelector('#everything').style.display = "block"; 
+		document.querySelector('#everything').style.display = 'block'; 
 		document.querySelector('#tooSmall').style.display = "none"; 
 	}
 };

--- a/html/analyze.html
+++ b/html/analyze.html
@@ -181,7 +181,7 @@ appendPortals()
 	}, {passive: true})
 
 	document.querySelector('#loadingDiv').style.display = "none";
-	document.querySelector('#analysisDiv').style.display = "block";
+	document.querySelector('#analysisDiv').style.display = 'block';
 
 })
 

--- a/html/analyze.html
+++ b/html/analyze.html
@@ -66,7 +66,6 @@
 
 </div>
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script>
 
@@ -79,12 +78,12 @@ let mirrorPortals = ['mirrorOn', 'mirrorOff']
 
 fetch(`../api${window.location.pathname}`).then(res => res.json()).then(res => {
 	if (!res.level) return window.location.href = window.location.href.replace("analyze", "search")
-	$('#levelName').text(res.level.name)
-	$('#objectCount').text(res.objects + " objects")
+	document.querySelector('#levelName').textContent = res.level.name;
+	document.querySelector('#objectCount').textContent = res.objects + " objects";
 	document.title = "Analysis of " + res.level.name
 
-	$('#meta-title').attr('content',  "Analysis of " + res.level.name)
-	$('#meta-desc').attr('content',  `${res.portals.split(",").length}x portals, ${res.orbs.total || 0}x orbs, ${res.triggers.total || 0}x triggers, ${res.misc.glow || 0}x glow...`)
+	document.querySelector('#meta-title').setAttribute('content', "Analysis of " + res.level.name);
+	document.querySelector('#meta-desc').setAttribute('content', `${res.portals.split(",").length}x portals, ${res.orbs.total || 0}x orbs, ${res.triggers.total || 0}x triggers, ${res.misc.glow || 0}x glow...`)
 
 let triggerList = Object.keys(res.triggers)
 let orbList = Object.keys(res.orbs)
@@ -95,27 +94,19 @@ let colorList = Object.keys(res.colors)
 let portals = res.portals.split(", ").map(x => x.split(" "))
 
 function appendPortals() {
-	$('#portals').html("")
-	if (res.settings.gamemode && res.settings.gamemode != "cube" && !disabledPortals.includes('form')) $('#portals').append(`<div class="inline portalDiv"><img class="portalImage" src='../objects/portal-${res.settings.gamemode}.png'><h3>Start</h3></div><img class="divider portalImage" src="../assets/divider.png" style="margin: 1.3% 0.8%">`)
-	if (res.settings.speed && res.settings.speed != "1x" && !disabledPortals.includes('speed')) $('#portals').append(`<div class="inline portalDiv"><img class="portalImage speedPortal" src='../objects/portal-${res.settings.speed}.png'><h3>Start</h3></div><img class="divider portalImage" src="../assets/divider.png" style="margin: 1.3% 0.8%">`)
-	
+	document.querySelector('#portals').innerHTML = "";
+	if (res.settings.gamemode && res.settings.gamemode != "cube" && !disabledPortals.includes('form')) document.querySelector('#portals').insertAdjacentHTML('beforeEnd', `<div class="inline portalDiv"><img class="portalImage" src='../objects/portal-${res.settings.gamemode}.png'><h3>Start</h3></div><img class="divider portalImage" src="../assets/divider.png" style="margin: 1.3% 0.8%">`)
+	if (res.settings.speed && res.settings.speed != "1x" && !disabledPortals.includes('speed')) document.querySelector('#portals').insertAdjacentHTML('beforeEnd', `<div class="inline portalDiv"><img class="portalImage speedPortal" src='../objects/portal-${res.settings.speed}.png'><h3>Start</h3></div><img class="divider portalImage" src="../assets/divider.png" style="margin: 1.3% 0.8%">`)
 
-	//$('#portals').append(`<img class="portalImage" src="../objects/portal-${res.settings.gamemode}.png" style="margin: 1.3% 0.8%"><img class="divider portalImage" src="../assets/divider.png" style="margin: 1.3% 0.8%">`)
-	//$('#portals').append(`<img class="portalImage speedPortal" src="../objects/portal-${res.settings.speed}.png" style="margin: 2% 0.8%"><img class="divider portalImage" src="../assets/divider.png" style="margin: 1.3% 0.8%">`)
+	let dividerCount = document.querySelectorAll('.divider').length - 1
 
-	//$('#portals').append(`<div class="inline portalDiv"><img class="portalImage speedPortal" src='../objects/portal-${res.settings.speed}.png'><h3>0%</h3></div><img class="divider portalImage" src="../assets/divider.png" style="margin: 1.3% 0.8%">`)
-
-	//
-
-	let dividerCount = $('.divider').length - 1
-
-	$('.divider').each(function(y) {
-		if (y != dividerCount) $(this).remove()
-	})
+	for (let y of document.querySelectorAll('.divider')) {
+		if (y != dividerCount) y.parentNode.removeChild(y);
+	}
 
 	portals.forEach(x => {
 		if (!x || x[0] == "") return;
-		$('#portals').append(`<div class="inline portalDiv"><img class="portalImage ${x[0].match(/[0-9]x/) ? "speedPortal" : ""}" src='../objects/portal-${x[0]}.png'><h3>${x[1]}</h3></div>`)
+		document.querySelector('#portals').insertAdjacentHTML('beforeEnd', `<div class="inline portalDiv"><img class="portalImage ${x[0].match(/[0-9]x/) ? "speedPortal" : ""}" src='../objects/portal-${x[0]}.png'><h3>${x[1]}</h3></div>`)
 	}
 
 	)}
@@ -123,65 +114,74 @@ function appendPortals() {
 appendPortals()
 
 	triggerList.forEach(x => {
-		if (x == "total") $('#triggerText').text(`Triggers (${res.triggers[x]})`)
-		else $('#triggers').append(`<div class="inline triggerDiv"><img height="50%" src='../objects/trigger-${x}.png'><h3 style="padding-top: 7%">x${res.triggers[x]}</h3></div>`)
+		if (x == "total") document.querySelector('#triggerText').textContent = `Triggers (${res.triggers[x]})`
+		else document.querySelector('#triggers').insertAdjacentHTML('beforeEnd', `<div class="inline triggerDiv"><img height="50%" src='../objects/trigger-${x}.png'><h3 style="padding-top: 7%">x${res.triggers[x]}</h3></div>`);
 	})
 	
 	orbList.forEach(x => {
-		if (x == "total") $('#orbText').text(`Jump Rings (${res.orbs[x]})`)
-		else $('#orbs').append(`<div class="inline orbDiv"><img height="50%" src='../objects/orb-${x}.png'><h3 style="padding-top: 7%">x${res.orbs[x]}</h3></div>`)
+		if (x == "total") document.querySelector('#orbText').textContent = `Jump Rings (${res.orbs[x]})`
+		else document.querySelector('#orbs').insertAdjacentHTML('beforeEnd', `<div class="inline orbDiv"><img height="50%" src='../objects/orb-${x}.png'><h3 style="padding-top: 7%">x${res.orbs[x]}</h3></div>`);
 	})
 
 	blockList.forEach(x => {
-		$('#blocks').append(`<div class="inline blockDiv"><img height="45%" src='../blocks/${x}.png'><h3 style="padding-top: 15%">x${res.blocks[x]}</h3></div>`)
+		document.querySelector('#blocks').insertAdjacentHTML('beforeEnd', `<div class="inline blockDiv"><img height="45%" src='../blocks/${x}.png'><h3 style="padding-top: 15%">x${res.blocks[x]}</h3></div>`)
 	})
 
 	miscList.forEach(x => {
 		if (x == "objects") return;
-		else $('#misc').append(`<div class="inline miscDiv"><img height="40%" src='../objects/obj-${x.slice(0, -1)}.png'><h3 style="padding-top: 15%">x${res.misc[x][0]}<br>${res.misc[x][1]}</h3></div>`)
+		else document.querySelector('#misc').insertAdjacentHTML('beforeEnd', `<div class="inline miscDiv"><img height="40%" src='../objects/obj-${x.slice(0, -1)}.png'><h3 style="padding-top: 15%">x${res.misc[x][0]}<br>${res.misc[x][1]}</h3></div>`)
 	})
 
 	colorList.forEach((x, y) => {
 		let c = res.colors[x]
-		$('#colorDiv').append(`${y % 8 == 0 ? "<brr>" : ""}<div class="inline aColor"><div style="background-color: rgba(${c.r}, ${c.g}, ${c.b}, ${c.opacity}); border: 0.4vh solid rgb(${c.r}, ${c.g}, ${c.b})">
+		document.querySelector('#colorDiv').insertAdjacentHTML('beforeEnd', `${y % 8 == 0 ? "<brr>" : ""}<div class="inline aColor"><div style="background-color: rgba(${c.r}, ${c.g}, ${c.b}, ${c.opacity}); border: 0.4vh solid rgb(${c.r}, ${c.g}, ${c.b})">
 		${c.copiedChannel ? `<h3 class='copiedColor'>C:${c.copiedChannel}</h3>` : c.pColor ? `<h3 class='copiedColor'>P${c.pColor}</h3>` : c.blending ? "<h3 class='blendingDot'>•</h3>" : ""}	
 		${c.opacity != "1" ? `<h3 class='copiedColor'>${c.opacity}%</h3>` : ""}
 		</div><h3 style="padding-top: 7%">${c.channel > 0 ? "Col " + c.channel : c.channel}</h3></div>`)
 	})
 
-	if (colorList.length == 0) $('#colorDiv').append('<h3 style="margin-top: 7vh">Level is too old to get color info!</h3>')
+	if (colorList.length == 0) document.querySelector('#colorDiv').insertAdjacentHTML('beforeEnd', '<h3 style="margin-top: 7vh">Level is too old to get color info!</h3>')
 
-	$(".portalToggle").click(function() {
-		if ($(this).prop('checked')) disabledPortals = disabledPortals.filter(x => x != $(this).attr('portal'))
-		else disabledPortals.push($(this).attr('portal'))
-		
-		portals = res.portals.split(", ").map(x => x.split(" "))
-		if (disabledPortals.includes('form')) portals = portals.filter(x => !formPortals.includes(x[0]))
-		if (disabledPortals.includes('speed')) portals = portals.filter(x => !speedPortals.includes(x[0]))
-		if (disabledPortals.includes('size')) portals = portals.filter(x => !sizePortals.includes(x[0]))
-		if (disabledPortals.includes('dual')) portals = portals.filter(x => !dualPortals.includes(x[0]))
-		if (disabledPortals.includes('mirror')) portals = portals.filter(x => !mirrorPortals.includes(x[0]))
+	for (let el of document.querySelectorAll(".portalToggle")) {
+		el.addEventListener('click', function() {
+			if (el.getAttribute('checked')) disabledPortals = disabledPortals.filter(x => x != el.getAttribute('portal'))
+			else disabledPortals.push(el.getAttribute('portal'))
+			
+			portals = res.portals.split(", ").map(x => x.split(" "))
+			if (disabledPortals.includes('form')) portals = portals.filter(x => !formPortals.includes(x[0]))
+			if (disabledPortals.includes('speed')) portals = portals.filter(x => !speedPortals.includes(x[0]))
+			if (disabledPortals.includes('size')) portals = portals.filter(x => !sizePortals.includes(x[0]))
+			if (disabledPortals.includes('dual')) portals = portals.filter(x => !dualPortals.includes(x[0]))
+			if (disabledPortals.includes('mirror')) portals = portals.filter(x => !mirrorPortals.includes(x[0]))
 
-		if (disabledPortals.includes('dupe')) {
-			portals.reverse().forEach((x, y) => {if (portals[y+1] && portals[y+1][0] == x[0]) portals[y][0] = null;})
-			portals = portals.reverse().filter(x => x[0] != null)
-		}
+			if (disabledPortals.includes('dupe')) {
+				portals.reverse().forEach((x, y) => {if (portals[y+1] && portals[y+1][0] == x[0]) portals[y][0] = null;})
+				portals = portals.reverse().filter(x => x[0] != null)
+			}
 
-		appendPortals()
-	})
+			appendPortals()
+		}, {passive: true})
+	}
 
-	$('#codeLength').html(`(${res.dataLength} characters)`)
+	document.querySelector('#codeLength').innerHTML = `(${res.dataLength} characters)`;
 
-	$('#revealCode').click(function() {
-		$('#levelCode').html('<p>Loading...</p>')
+	document.querySelector('#revealCode').addEventListener('click', function() {
+		let levelCode = document.querySelector('#levelCode');
+		levelCode.innerHTML = '<p>Loading...</p>';
 
-	window.setTimeout(function () { //small delay so "loading" message appears
-		$('#levelCode').html(`<p class="codeFont">${res.data}</p>`)}, 50);
-		$('#levelCode').focus().select()
-	})
+		window.setTimeout(function () { //small delay so "loading" message appears
+			levelCode.innerHTML = `<p class="codeFont">${res.data}</p>`
+			levelCode.focus();
+			let selectionRange = document.createRange();
+			selectionRange.selectNode(levelCode);
+			let selection = getSelection();
+			selection.removeAllRanges();
+			selection.addRange(selectionRange);
+		}, 50);
+	}, {passive: true})
 
-	$('#loadingDiv').hide()
-	$('#analysisDiv').show()
+	document.querySelector('#loadingDiv').style.display = "none";
+	document.querySelector('#analysisDiv').style.display = "block";
 
 })
 

--- a/html/api.html
+++ b/html/api.html
@@ -69,14 +69,14 @@
 			<p>Using "daily" or "weekly" as the level ID will return the current daily/weekly level (always downloaded)</p>
 
 			<br>
-			<p class="reveal" onclick="$('#params-level').slideToggle(100);"><b>Parameters (1)</b></p>
+			<p class="reveal" onclick="slideToggle('params-level')"><b>Parameters (1)</b></p>
 			<div class="subdiv" id="params-level">
 				<p>download: Whether or not to actually download the level (much slower)</p>
 				<p>*By default it performs a search for the level ID and returns as much information as possible without downloading</p>
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#response-level').slideToggle(100);"><b>Response (36)</b></p>
+			<p class="reveal" onclick="slideToggle('response-level')"><b>Response (36)</b></p>
 			<div class="subdiv" id="response-level">
 				<p class="br">*Values that require a download are in
 					<span style="color:red">red</span>
@@ -121,7 +121,7 @@
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#request-level').slideToggle(100)"><b>Example</b></p>
+			<p class="reveal" onclick="slideToggle('request-level')"><b>Example</b></p>
 			<div class="subdiv" id="request-level">
 				<p><b>Example Request</b></p>
 				<p>/api/level/4284013 </p>
@@ -148,13 +148,13 @@
 			<p>Unlike the Geometry Dash API, both username and ID can be used to fetch a user profile.</p>
 
 			<br>
-			<p class="reveal" onclick="$('#params-profile').slideToggle(100)"><b>Parameters (0)</b></p>
+			<p class="reveal" onclick="slideToggle('params-profile')"><b>Parameters (0)</b></p>
 			<div class="subdiv" id="params-profile">
 				<p>No parameters for this one!</p>
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#response-profile').slideToggle(100)"><b>Response (28)</b></p>
+			<p class="reveal" onclick="slideToggle('response-profile')"><b>Response (28)</b></p>
 			<div class="subdiv" id="response-profile">
 				<p>username: The name of the player</p>
 				<p>playerID: The unique ID for all accounts</p>
@@ -178,7 +178,7 @@
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#request-profile').slideToggle(100)"><b>Example</b></p>
+			<p class="reveal" onclick="slideToggle('request-profile')"><b>Example</b></p>
 			<div class="subdiv" id="request-profile">
 				<p><b>Example Request</b></p>
 				<p>/api/profile/robtop</p>
@@ -205,7 +205,7 @@
 			<p>Use an asterisk (*) as your search query if you do not wish to search by level name (if you intend on using filters)</p>
 
 			<br>
-			<p class="reveal" onclick="$('#params-search').slideToggle(100)"><b>Parameters (17)</b></p>
+			<p class="reveal" onclick="slideToggle('params-search')"><b>Parameters (17)</b></p>
 			<div class="subdiv" id="params-search">
 				<p>Buckle up... there's a lot</p>
 
@@ -252,12 +252,12 @@
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#response-search').slideToggle(100)"><b>Response*</b></p>
+			<p class="reveal" onclick="slideToggle('response-search')"><b>Response*</b></p>
 			<div class="subdiv" id="response-search">
 				<p>The response for searching is an array of up to 10 <a href="#level">level objects</a></p>
 			</div>
 			<br>
-			<p class="reveal" onclick="$('#request-search').slideToggle(100)"><b>Examples</b></p>
+			<p class="reveal" onclick="slideToggle('request-search')"><b>Examples</b></p>
 			<div class="subdiv" id="request-search">
 				<p><b>Example Requests</b></p>
 				<p>/api/search/abc (Searches for a level named "abc")</p>
@@ -286,7 +286,7 @@
 			<p>Simply returns the top player leaderboard</p>
 
 			<br>
-			<p class="reveal" onclick="$('#params-leaderboard').slideToggle(100)"><b>Parameters (3)</b></p>
+			<p class="reveal" onclick="slideToggle('params-leaderboard')"><b>Parameters (3)</b></p>
 			<div class="subdiv" id="params-leaderboard">
 				<p>count: The amount of players to list (default is 100, max is 2500, does not work with accurate leaderboard)</p>
 				<p>creator: Fetches the creator leaderboard</p>
@@ -294,7 +294,7 @@
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#response-leaderboard').slideToggle(100)"><b>Response (9)</b></p>
+			<p class="reveal" onclick="slideToggle('response-leaderboard')"><b>Response (9)</b></p>
 			<div class="subdiv" id="response-leaderboard">
 				<p>The API will return an array of each player with the following information:</p>
 				<p>rank: Position on the leaderboard</p>
@@ -309,7 +309,7 @@
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#request-leaderboard').slideToggle(100)"><b>Examples</b></p>
+			<p class="reveal" onclick="slideToggle('request-leaderboard')"><b>Examples</b></p>
 			<div class="subdiv" id="request-leaderboard">
 				<p><b>Example Requests</b></p>
 				<p>/api/leaderboard?count=10 (Fetches the top 10 players)</p>
@@ -337,14 +337,14 @@
 			<p>Returns the leaderboard for a level</p>
 
 			<br>
-			<p class="reveal" onclick="$('#params-levelleaderboard').slideToggle(100)"><b>Parameters (2)</b></p>
+			<p class="reveal" onclick="slideToggle('params-levelleaderboard')"><b>Parameters (2)</b></p>
 			<div class="subdiv" id="params-levelleaderboard">
 				<p>count: The amount of players to list (default is 100, max is 200)</p>
 				<p>week: Whether or not to fetch the weekly leaderboard instead of the regular one</p>
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#response-levelleaderboard').slideToggle(100)"><b>Response (6)</b></p>
+			<p class="reveal" onclick="slideToggle('response-levelleaderboard')"><b>Response (6)</b></p>
 			<div class="subdiv" id="response-levelleaderboard">
 				<p>The API will return an array of each player with the following information:</p>
 				<p>rank: Position on the leaderboard</p>
@@ -357,7 +357,7 @@
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#request-levelleaderboard').slideToggle(100)"><b>Example</b></p>
+			<p class="reveal" onclick="slideToggle('request-levelleaderboard')"><b>Example</b></p>
 			<div class="subdiv" id="request-levelleaderboard">
 				<p><b>Example Request</b></p>
 				<p>/api/leaderboardLevel/1063115 (Fetches the leaderboard for Dynamic on Track)</p>
@@ -382,7 +382,7 @@
 			<p>Returns up to 10 comments or profile posts</p>
 
 			<br>
-			<p class="reveal" onclick="$('#params-comment').slideToggle(100)"><b>Parameters (3)</b></p>
+			<p class="reveal" onclick="slideToggle('params-comment')"><b>Parameters (3)</b></p>
 			<div class="subdiv" id="params-comment">
 				<p>top: Whether or not to sort by most liked (comments only)</p>
 				<p>page: The page of the search</p>
@@ -392,7 +392,7 @@
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#response-comment').slideToggle(100)"><b>Response (10)</b></p>
+			<p class="reveal" onclick="slideToggle('response-comment')"><b>Response (10)</b></p>
 			<div class="subdiv" id="response-comment">
 				<p>The API will return an array of each comment with the following information.<br>Values that don't work for profile posts are in <font color=red>red</font></p>
 				<p>content: The comment text</p>
@@ -408,7 +408,7 @@
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#request-comment').slideToggle(100)"><b>Examples</b></p>
+			<p class="reveal" onclick="slideToggle('request-comment')"><b>Examples</b></p>
 			<div class="subdiv" id="request-comment">
 				<p><b>Example Requests</b></p>
 				<p>/api/comments/26681070?top (Fetches Sonic Wave's most liked comments)</p>
@@ -426,7 +426,7 @@
 	</main>
 	<main class="alt">
 		<div class="main-block">
-			<div id="analyze""></div>
+			<div id="analyze"></div>
 			<h1>Level Analysis (WIP)</h1>
 			<p>/api/analyze/levelID</p>
 
@@ -434,13 +434,13 @@
 			<p><b>Level analyzing is still a big WIP so there may be changes in the future</b></p>
 
 			<br>
-			<p class="reveal" onclick="$('#params-analyze').slideToggle(100)"><b>Parameters (0)</b></p>
+			<p class="reveal" onclick="slideToggle('params-analyze')"><b>Parameters (0)</b></p>
 			<div class="subdiv" id="params-analyze">
 				<p>No parameters for this one!</p>
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#response-analyze').slideToggle(100)"><b>Response (?)</b></p>
+			<p class="reveal" onclick="slideToggle('response-analyze')"><b>Response (?)</b></p>
 			<div class="subdiv" id="response-analyze">
 				<p><b>Response is subject to change in the future</b></p>
 				<p>The API will return an array of each player with the following information:</p>
@@ -470,19 +470,36 @@
 </body>
 
 </html>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-<script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script>
-	$('.subdiv').each(function() {
-		$(this).html($(this).html().replace(/(<p.*>)(.*:) /g, '$1<font class="param">$2</font> '))
-	})
+	let transitionHeights = [];
+	for (let el of document.querySelectorAll('.subdiv')) {
+		el.style.visibility = 'hidden'; // Dumb but needed to work with polyfilled slideToggle
+		el.innerHTML = el.innerHTML.replace(/(<p.*>)(.*:) /g, '$1<font class="param">$2</font> ');
+	}
 
-	$('.fetch').each(function() {
-		fetch(`..${$(this).attr('link')}`).then(res => res.json()).then(res => {
-			$(this).html(JSON.stringify(res, null, 2))
+	for (let el of document.querySelectorAll('.fetch')) {
+		fetch(`..${el.getAttribute('link')}`).then(res => res.json()).then(res => {
+			el.innerHTML = JSON.stringify(res, null, 2)
 		})
-	});
-
+	}
+	function slideToggle(id) {
+		let el = document.getElementById(id);
+		let style = el.style
+		if (style.visibility == 'hidden') {
+			style.height = 'auto';
+			let transitionTo = el.clientHeight - 10; // Account for padding
+			style.height = 0;
+			style.transition = 'all 100ms ease-in-out';
+			style.visibility = 'visible';
+			style.height = transitionTo+'px';
+			style.transform = 'scaleY(1)';
+		} else {
+			style.visibility = 'hidden';
+			style.transform = 'scaleY(0)';
+			style.height = 0;
+			delete style.transition;
+		}
+	}
 
 	//smooth scrolling through anchors
 	document.querySelectorAll('a[href^="#"]').forEach(anchor => {

--- a/html/api.html
+++ b/html/api.html
@@ -394,7 +394,7 @@
 			<br>
 			<p class="reveal" onclick="slideToggle('response-comment')"><b>Response (10)</b></p>
 			<div class="subdiv" id="response-comment">
-				<p>The API will return an array of each comment with the following information.<br>Values that don't work for profile posts are in <font color=red>red</font></p>
+				<p>The API will return an array of each comment with the following information.<br>Values that don't work for profile posts are in <span style="color:red">red</span></p>
 				<p>content: The comment text</p>
 				<p>likes: The number of likes the comment has</p>
 				<p>date: Time since the comment was posted (sent as "x days/weeks/months" ago, since it's all the API sends)</p>
@@ -474,7 +474,7 @@
 	let transitionHeights = [];
 	for (let el of document.querySelectorAll('.subdiv')) {
 		el.style.visibility = 'hidden'; // Dumb but needed to work with polyfilled slideToggle
-		el.innerHTML = el.innerHTML.replace(/(<p.*>)(.*:) /g, '$1<font class="param">$2</font> ');
+		el.innerHTML = el.innerHTML.replace(/(<p.*>)(.*:) /g, '$1<span class="param">$2</span> ');
 	}
 
 	for (let el of document.querySelectorAll('.fetch')) {

--- a/html/comments.html
+++ b/html/comments.html
@@ -79,110 +79,107 @@ if (!Number(lvlID)) {history = true; target = `../api/profile/${lvlID}`}
 fetch(target).then(res => res.json()).then(lvl => {
 
 	if (history) {
-		$('#levelName').text(lvl.username + "'s comments")
+		document.querySelector('#levelName').textContent = lvl.username + "'s comments";
 		document.title = lvl.username + "'s comments"
 
-		$('#meta-title').attr('content', lvl.username + "'s comment history")
-		$('#meta-desc').attr('content',  `View all of ${lvl.username}'s Geometry Dash comments!`)
+		document.querySelector('#meta-title').setAttribute('content', lvl.username + "'s comment history")
+		document.querySelector('#meta-desc').setAttribute('content',  `View all of ${lvl.username}'s Geometry Dash comments!`)
 	}
 
 	else {
-		if (lvl.accountID == "0") $('#levelAuthor').addClass("green")
-		$('#levelName').text(lvl.name || ("Nonexistent level " + lvlID))
-		$('#levelAuthor').text("By " + (lvl.author || "-"))
-		$('#levelID').text("ID: " + lvlID)
-		$('#levelVersion').text("Version: " + (lvl.version || 0))
+		if (lvl.accountID == "0") document.querySelector('#levelAuthor').classList.add("green")
+		document.querySelector('#levelName').textContent = lvl.name || ("Nonexistent level " + lvlID);
+		document.querySelector('#levelAuthor').textContent = "By " + (lvl.author || "-");
+		document.querySelector('#levelID').textContent = "ID: " + lvlID;
+		document.querySelector('#levelVersion').textContent = "Version: " + (lvl.version || 0);
 		document.title = "Comments for " + (lvl.name || lvlID)
 
 		if (lvl.name) {
-			$('#meta-title').attr('content', `Comments for ${lvl.name}`)
-			$('#meta-desc').attr('content',  `View all the comments for ${lvl.name} by ${lvl.author || "Unknown"}!`)
+			document.querySelector('#meta-title').setAttribute('content', `Comments for ${lvl.name}`)
+			document.querySelector('#meta-desc').setAttribute('content',  `View all the comments for ${lvl.name} by ${lvl.author || "Unknown"}!`)
 		}
 	}
 
-function appendComments() {
+	function appendComments() {
 
-if (loadingComments) return;
-else loadingComments = true;
+		if (loadingComments) return;
+		else loadingComments = true;
 
-$('#commentBox').html(`<div class="supercenter" id="loading" style="height: 12%;"><img class="spin noSelect" src="../assets/loading.png" height="105%"></div>`)
+		document.querySelector('#commentBox').insertAdjacentHTML('beforeEnd', `<div class="supercenter" id="loading" style="height: 12%;"><img class="spin noSelect" src="../assets/loading.png" height="105%"></div>`);
 
-if (page == 0) $('#pageDown').hide()
-else $('#pageDown').show()
+		if (page == 0) document.querySelector('#pageDown').style.display = "none";
+		else document.querySelector('#pageDown').style.display = "block";
 
-fetch(`../api${!history ? window.location.pathname : "/comments/" + lvl.playerID}?page=${page}${history ? "&type=commentHistory" : ""}${mode == "top" ? "&top" : ""}`).then(res => res.json()).then(res => {
-	
-	if (res.length < 9 || (history && lvl.commentHistory == "off")) $('#pageUp').hide()
-	else $('#pageUp').show()
+		fetch(`../api${!history ? window.location.pathname : "/comments/" + lvl.playerID}?page=${page}${history ? "&type=commentHistory" : ""}${mode == "top" ? "&top" : ""}`).then(res => res.json()).then(res => {
+			
+			if (res.length < 9 || (history && lvl.commentHistory == "off")) document.querySelector('#pageUp').style.display = "none"
+			else document.querySelector('#pageUp').style.display = "block"
 
-	if (res == -1 || (history && lvl.commentHistory == "off")) {
-		return $('#loading').hide()
-	}
+			if (res == -1 || (history && lvl.commentHistory == "off")) {
+				return document.querySelector('#loading').style.display = "none";
+			}
+			let commentBox = document.querySelector('#commentBox');
+			commentBox.innerHTML = res.map(x => `
+				<div class="commentBG">
+					<div class="comment">
+						<img class="inline" src="../icon/${!history ? x.username : lvl.username}?form=${x.form}" height=21% style="margin-right: 0.8%">
+						<a ${x.username == "Unknown" || x.accountID == "0" ? "" : "href"}="../profile/${!history ? x.username : lvl.username}"><h2 class="inline ${x.username == "Unknown" || x.accountID == "0" ? "green" : "gdButton"}">${!history ? x.username : lvl.username}</h2></a>
+						${x.modColor || lvl.moderator == "2" ? `<img class="inline" src="../assets/mod-elder.png" height=18% style="margin-left: 0.6%;">` : ""}
+						<p class="commentPercent inline">${x.percent ? x.percent + "%" : ""}</p>
 
-	res.forEach(x => {
-		$('#commentBox').append(`
-			<div class="commentBG">
-				<div class="comment">
-					<img class="inline" src="../icon/${!history ? x.username : lvl.username}?form=${x.form}" height=21% style="margin-right: 0.8%">
-					<a ${x.username == "Unknown" || x.accountID == "0" ? "" : "href"}="../profile/${!history ? x.username : lvl.username}"><h2 class="inline ${x.username == "Unknown" || x.accountID == "0" ? "green" : "gdButton"}">${!history ? x.username : lvl.username}</h2></a>
-					${x.modColor || lvl.moderator == "2" ? `<img class="inline" src="../assets/mod-elder.png" height=18% style="margin-left: 0.6%;">` : ""}
-					<p class="commentPercent inline">${x.percent ? x.percent + "%" : ""}</p>
-
-					<div class="commentAlign">
-						<p class="commentText" style="color: ${!history && x.playerID == lvl.authorID ? "rgb(255, 255, 75)" : x.username == "RobTop" ? "rgb(50, 255, 255)" : x.modColor || lvl.moderator == "2" ? `rgb(75, 255, 75)` : "white"}">${x.content}</p>
+						<div class="commentAlign">
+							<p class="commentText" style="color: ${!history && x.playerID == lvl.authorID ? "rgb(255, 255, 75)" : x.username == "RobTop" ? "rgb(50, 255, 255)" : x.modColor || lvl.moderator == "2" ? `rgb(75, 255, 75)` : "white"}">${x.content}</p>
+						</div>
 					</div>
-				</div>
-				<p class="commentDate">${x.date}</p>
-				<div class="commentLikes">
-					${history ? `<h3 style="margin-right: 1.5vh; pointer-events: all;" class="gold inline"><a href="../${x.levelID}">(${x.levelID})</a></h3>` : ""}
-					<img id="likeImg" class="inline" ${x.likes < 0 ? "style='transform: translateY(25%)'" : ""} src="../assets/${x.likes < 0 ? "dis" : ""}like.png" height=20% style="margin-right: 0.4%">
-					<h3 class="inline">${x.likes}</h3>
-				</div>
-			</div>`)
-	})
+					<p class="commentDate">${x.date}</p>
+					<div class="commentLikes">
+						${history ? `<h3 style="margin-right: 1.5vh; pointer-events: all;" class="gold inline"><a href="../${x.levelID}">(${x.levelID})</a></h3>` : ""}
+						<img id="likeImg" class="inline" ${x.likes < 0 ? "style='transform: translateY(25%)'" : ""} src="../assets/${x.likes < 0 ? "dis" : ""}like.png" height=20% style="margin-right: 0.4%">
+						<h3 class="inline">${x.likes}</h3>
+					</div>
+				</div>`).join('');
 
-	$('.commentText').each(function() {
-	if ($(this).text().length > 100) {
-	let overflow = ($(this).text().length - 100) * 0.01
-	$(this).css('font-size', (3.5 - (overflow)) + 'vh')
+			for (let el of document.querySelectorAll('.commentText')) {
+				if (el.textContent.length > 100) {
+					let overflow = (el.textContent.length - 100) * 0.01
+					el.style.fontSize = (3.5 - (overflow)) + 'vh'
+				}
+			};
+			commentBox.scrollTop = 0;
+		})
+		loadingComments = false;
 	}
-});
-$('#loading').hide()
-})
-loadingComments = false;
-}
 
-let mode = "time"
-let page = 0
-let loadingComments = false
-appendComments()
-
-$('#pageUp').click(function() {page += 1; appendComments()})
-$('#pageDown').click(function() {page -= 1; appendComments()})
-
-$('#topSort').click(function() {
-	if (mode == "top") return;
-	mode = "top";
-	page = 0;
-	$('#timeSort').attr('src', "../assets/sort-time.png")
-	$('#topSort').attr('src', "../assets/sort-likes-on.png")
+	let mode = "time"
+	let page = 0
+	let loadingComments = false
 	appendComments()
-})
 
-$('#timeSort').click(function() {
-	if (mode == "time") return;
-	mode = "time";
-	page = 0;
-	$('#timeSort').attr('src', "../assets/sort-time-on.png")
-	$('#topSort').attr('src', "../assets/sort-likes.png")
-	appendComments()
-})
+	document.querySelector('#pageUp').addEventListener('click', function() {page += 1; appendComments()}, {passive: true})
+	document.querySelector('#pageDown').addEventListener('click', function() {page -= 1; appendComments()}, {passive: true})
 
-$('#refresh').click(function() {
-	page = 0;
-	appendComments()
-})
+	document.querySelector('#topSort').addEventListener('click', function() {
+		if (mode == "top") return;
+		mode = "top";
+		page = 0;
+		document.querySelector('#timeSort').setAttribute('src', "../assets/sort-time.png")
+		document.querySelector('#topSort').setAttribute('src', "../assets/sort-likes-on.png")
+		appendComments()
+	}, {passive: true})
 
+	document.querySelector('#timeSort').addEventListener('click', function() {
+		if (mode == "time") return;
+		mode = "time";
+		page = 0;
+		document.querySelector('#timeSort').setAttribute('src', "../assets/sort-time-on.png")
+		document.querySelector('#topSort').document.querySelector('src', "../assets/sort-likes.png")
+		appendComments()
+	}, {passive: true})
+
+	document.querySelector('#refresh').addEventListener('click', function() {
+		page = 0;
+		appendComments()
+	}, {passive: true})
 })
 
 

--- a/html/comments.html
+++ b/html/comments.html
@@ -64,7 +64,6 @@
 </div>
 
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script type="text/javascript" src="https://asvd.github.io/dragscroll/dragscroll.js"></script>
 <script>
@@ -108,12 +107,12 @@ fetch(target).then(res => res.json()).then(lvl => {
 		document.querySelector('#commentBox').insertAdjacentHTML('beforeEnd', `<div class="supercenter" id="loading" style="height: 12%;"><img class="spin noSelect" src="../assets/loading.png" height="105%"></div>`);
 
 		if (page == 0) document.querySelector('#pageDown').style.display = "none";
-		else document.querySelector('#pageDown').style.display = "block";
+		else document.querySelector('#pageDown').style.display = 'block';
 
 		fetch(`../api${!history ? window.location.pathname : "/comments/" + lvl.playerID}?page=${page}${history ? "&type=commentHistory" : ""}${mode == "top" ? "&top" : ""}`).then(res => res.json()).then(res => {
 			
 			if (res.length < 9 || (history && lvl.commentHistory == "off")) document.querySelector('#pageUp').style.display = "none"
-			else document.querySelector('#pageUp').style.display = "block"
+			else document.querySelector('#pageUp').style.display = 'block'
 
 			if (res == -1 || (history && lvl.commentHistory == "off")) {
 				return document.querySelector('#loading').style.display = "none";

--- a/html/filters.html
+++ b/html/filters.html
@@ -158,7 +158,7 @@ for (let el of document.querySelectorAll('.diffDiv')) {
 	el.addEventListener('click', function() {
 		if (el.classList.contains('goBack')) {
 			demonMode = false;
-			document.querySelector('#difficulties').style.display = "block";
+			document.querySelector('#difficulties').style.display = 'block';
 			document.querySelector('#demonBtn').classList.remove('selectedFilter')
 			for (let el of document.querySelectorAll('.demonDiff')) el.classList.remove('selectedFilter');
 			document.querySelector('#demons').style.display = "none";
@@ -181,7 +181,7 @@ for (let el of document.querySelectorAll('.diffDiv')) {
 
 		if (el.getAttribute('diff') == -2) {
 			document.querySelector('#difficulties').style.display = "none";
-			document.querySelector('#demons').style.display = "block";
+			document.querySelector('#demons').style.display = 'block';
 			demonMode = true;
 		}
 	}, {passive: true})

--- a/html/filters.html
+++ b/html/filters.html
@@ -15,7 +15,7 @@
 
 	<div id="filters" class="popup">
 		<div id="filterStuff" class="brownBox bounce center supercenter" style="width: 101vh; height: 50%; padding-top: 0.3%; padding-bottom: 3.5%; padding-left: 1%">
-			<img class="gdButton" src="../assets/close.png" width="9%" style="position: absolute; top: -8.5%; left: -5.5vh" onclick="$('#filters').hide()">
+			<img class="gdButton" src="../assets/close.png" width="9%" style="position: absolute; top: -8.5%; left: -5.5vh" onclick="document.querySelector('#filters').style.display = 'none'">
 			<h1 style="margin-bottom: 4%">Advanced Options</h1><br>
 			<div><h1><input type="checkbox" id="box1" url="&featured"><label for="box1" class="gdcheckbox gdButton"></label>Featured</h1></div>
 			<div><h1><input type="checkbox" id="box2" url="&epic"><label for="box2" class="gdcheckbox gdButton"></label>Epic</h1></div>
@@ -96,13 +96,12 @@
 	</div>
 
 	<div style="position:absolute; top: 2%; right: 1.5%; width: 10%; text-align: right">
-		<img class="gdButton" src="../assets/plus.png" width="60%" onclick="$('#filters').show()">
+		<img class="gdButton" src="../assets/plus.png" width="60%" onclick="document.querySelector('#filters').style.display = 'block'">
 	</div>
 
 </div>
 
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script>
 
@@ -111,85 +110,88 @@ let minusCheck = []
 let demons = []
 let demonMode = false;
 
-$('#userSearch').click(function() {
-	let query = encodeURIComponent($('#levelName').val())
+document.querySelector('#userSearch').addEventListener('click', function() {
+	let query = encodeURIComponent(document.querySelector('#levelName').value)
 	if (query) window.location.href = "./profile/" + query
-})
+}, {passive: true})
 
-$('.levelSearch').click(function() {
+for (let el of document.querySelectorAll('.levelSearch')) {
+	el.addEventListener('click', function() {
 
-	let url = "./search/" + (encodeURIComponent($('#levelName').val()) || "*") + "?type=" + $(this).attr('search')
+		let url = "./search/" + (encodeURIComponent(document.querySelector('#levelName').value) || "*") + "?type=" + el.getAttribute('search')
 
-	// === DIFFICULTY === //
-	let difficulties = []
-	$('.diffDiv').each(function() {if ($(this).hasClass('selectedFilter')) difficulties.push($(this).attr('diff'))})
-	demonFilter = demonMode && difficulties[0] > 0
-	
-	if (!difficulties.length) url += ""
-	else if (!demonFilter) url += "&diff=" + difficulties.join(",")
-	else url += "&diff=-2&demonFilter=" + difficulties[0]
+		// === DIFFICULTY === //
+		let difficulties = []
+		for (let el of document.querySelectorAll('.diffDiv')) {if (el.classList.contains('selectedFilter')) difficulties.push(el.getAttribute('diff'))}
+		demonFilter = demonMode && difficulties[0] > 0
 
-	// === LENGTH === //
-	let lengths = []
-	$('.lengthDiv').each(function() {if ($(this).hasClass('selectedFilter') && $(this).attr('len')) lengths.push($(this).attr('len'))})
-	if (lengths.length) url += "&length=" + lengths.join(",")
-	if ($('#starCheck').hasClass('selectedFilter')) url += "&starred"
+		if (!difficulties.length) url += ""
+		else if (!demonFilter) url += "&diff=" + difficulties.join(",")
+		else url += "&diff=-2&demonFilter=" + difficulties[0]
 
-	// === CHECKBOXES === //
-    $("input:checked").each(function () {
-	url += $(this).attr('url')})
+		// === LENGTH === //
+		let lengths = []
+		for (let el of document.querySelectorAll('.lengthDiv')) {if (el.classList.contains('selectedFilter') && el.getAttribute('len')) lengths.push(el.getAttribute('len'))}
+		if (lengths.length) url += "&length=" + lengths.join(",")
+		if (document.querySelector('#starCheck').classList.contains('selectedFilter')) url += "&starred"
 
-	// === SONG === //
+		// === CHECKBOXES === //
+		for (let el of document.querySelectorAll("input:checked")) {
+			url += el.getAttribute('url')
+		}
 
-	if ($('#songID').val()) {
+		// === SONG === //
 
-	url += "&songID=" + $('#songID').val()
-	if (/^\d+$/.test($('#songID').val())) url += "&customSong"
-	}
+		if (document.querySelector('#songID').value) {
 
-	if (url.endsWith('?type=0')) url = url.slice(0, -7)
+		url += "&songID=" + document.querySelector('#songID').value
+		if (/^\d+$/.test(document.querySelector('#songID').value)) url += "&customSong"
+		}
 
-	window.location.href = url.replace(/\?type=0&/, "?")
+		if (url.endsWith('?type=0')) url = url.slice(0, -7)
 
-})
+		window.location.href = url.replace(/\?type=0&/, "?")
 
-$('.diffDiv').click(function() {
+	}, {passive: true})
+}
+for (let el of document.querySelectorAll('.diffDiv')) {
+	el.addEventListener('click', function() {
+		if (el.classList.contains('goBack')) {
+			demonMode = false;
+			document.querySelector('#difficulties').style.display = "block";
+			document.querySelector('#demonBtn').classList.remove('selectedFilter')
+			for (let el of document.querySelectorAll('.demonDiff')) el.classList.remove('selectedFilter');
+			document.querySelector('#demons').style.display = "none";
+		}
 
-	if ($(this).hasClass('goBack')) {
-		demonMode = false;
-		$('#difficulties').show();
-		$('#demonBtn').removeClass('selectedFilter')
-		$('.demonDiff').removeClass('selectedFilter')
-		return $('#demons').hide();
-	}
+		minusCheck = []
+		filters = []
+		el.classList.toggle('selectedFilter')
 
-	minusCheck = []
-	filters = []
-	$(this).toggleClass('selectedFilter')
+		for (let el of document.querySelectorAll('.diffDiv')) {
+			if (el.classList.contains('selectedFilter')) filters.push(el.getAttribute('diff'))
+		}
 
-	$('.diffDiv').each(function() {
-	if ($(this).hasClass('selectedFilter')) filters.push($(this).attr('diff'))})
+		minusCheck = filters.filter(x => x < 0)
+		if (minusCheck.length || el.classList.contains('demonDiff')) {
+			filters = minusCheck
+			for (let el of document.querySelectorAll('.diffDiv')) el.removeClass('selectedFilter')
+			el.addClass('selectedFilter')
+		}
 
-	minusCheck = filters.filter(x => x < 0)
-	if (minusCheck.length || $(this).hasClass('demonDiff')) {
-		filters = minusCheck
-		$('.diffDiv').removeClass('selectedFilter')
-		$(this).addClass('selectedFilter')
-	}
+		if (el.getAttribute('diff') == -2) {
+			document.querySelector('#difficulties').style.display = "none";
+			document.querySelector('#demons').style.display = "block";
+			demonMode = true;
+		}
+	}, {passive: true})
+}
 
-	if ($(this).attr('diff') == -2) {
-		$('#difficulties').hide();
-		$('#demons').show();
-		demonMode = true;
-	}
-})
-
-$('.lengthDiv').click(function() {
-	$(this).toggleClass('selectedFilter')
-})
-
-$(document).keydown(function(k) {
-	if (k.which == 13 && $('#filters').is(':hidden')) $('#searchBtn').trigger('click') //enter
-})
-
+for (let el of document.querySelectorAll('.lengthDiv'))
+	el.addEventListener('click', function() {
+		el.classList.toggle('selectedFilter')
+	}, {passive: true});
+document.addEventListener('keydown', function(k) {
+	if (k.code == "Enter" && document.querySelector('#filters').style.display == "none") document.querySelector('#searchBtn').click() //enter
+}, {passive: true})
 </script>

--- a/html/gauntlets.html
+++ b/html/gauntlets.html
@@ -29,21 +29,13 @@
 	
 </div>
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script>
 
 let gauntlets = ["Fire", "Ice", "Poison", "Shadow", "Lava", "Bonus", "Chaos", "Demon", "Time", "Crystal", "Magic", "Spike", "Monster", "Doom", "Death"]
-
-gauntlets.forEach((x, y) => {
-
-$('#gauntletList').append(`
+document.querySelector('#gauntletList').insertAdjacentHTML('beforeEnd', gauntlets.map((x, y) => `
 			<div class="gauntlet">
 			<a href="../search/level?gauntlet=${y + 1}">
 			<img src="../gauntlets/${x.toLowerCase()}.png" height="300%"><br>
-			<h3 class="gauntletText"">${x}<br>Gauntlet</h3></div></a>`)
-})
-
-
-
+			<h3 class="gauntletText"">${x}<br>Gauntlet</h3></div></a>`).join(''))
 </script>

--- a/html/home.html
+++ b/html/home.html
@@ -68,23 +68,24 @@
 </div>
 
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script>
 
 let page = 1
-$('#browserlogo').css('filter', `hue-rotate(${Math.floor(Math.random() * (330 - 60)) + 60}deg) saturate(${Math.floor(Math.random() * (150 - 100)) + 100}%)`)
+let creditsNode = document.querySelector('#credits');
+document.querySelector('#browserlogo').style.filter = `hue-rotate(${Math.floor(Math.random() * (330 - 60)) + 60}deg) saturate(${Math.floor(Math.random() * (150 - 100)) + 100}%)`;
 
 function loadCredits() {
-	$('.subCredits').hide()
-	$('#credits' + page).show()
-	$('#credits').show()
+	for (let el of document.querySelectorAll('.subCredits')) {
+		el.style.display = "none";
+		if (el.id == "credits"+page)
+			el.style.display = "block";
+	}
+	document.querySelector('#credits').style.display = "block";
 }
 
 fetch(`./api/credits`).then(res => res.json()).then(res => {
-
-	res.credits.forEach((x, y) => {
-		$('#credits').append(`<div id="credits${y+1}" class="subCredits" style="display: none;">
+	creditsNode.insertAdjacentHTML('beforeEnd', res.credits.map((x, y) => `<div id="credits${y+1}" class="subCredits" style="display: none;">
 			<div class="brownBox center supercenter" style="width: 80vh; height: 43%; padding-top: 1.5%; padding-bottom: 3.5%;">
 				<h1>${x.header}</h1><br>
 				<h2 style="margin-bottom: 1.5%" class="gdButton"><a href="./profile/${x.ign || x.name}">${x.name}</h2></a>
@@ -96,40 +97,30 @@ fetch(`./api/credits`).then(res => res.json()).then(res => {
 			</div>
 			<img class="gdButton" src="../assets/arrow-right.png" width="60vh" style="position: absolute; top: 45%; left: 75%" onclick="page += 1; loadCredits()">
 			<img class="gdButton" src="../assets/arrow-left.png" width="60vh" style="${y == 0 ? "display: none; " : ""}position: absolute; top: 45%; right: 75%" onclick="page -= 1; loadCredits()">
-		</div>`)
-	})
-
-	$('#credits').append(`<div id="credits${res.credits.length + 1}" class="subCredits" style="display: none;">
+		</div>`).join(''));
+	creditsNode.insertAdjacentHTML('beforeEnd', `<div id="credits${res.credits.length + 1}" class="subCredits" style="display: none;">
 			<div id="githubbers" class="brownBox center supercenter" style="width: 80vh; height: 43%; padding-top: 1.5%; padding-bottom: 3.5%;">
 				<h1>GitHub Contributors</h1><br>
+				${res.contributors.map((x, y) => `<div class="githubChad">
+				<h2 class="gdButton smaller"><a href="./profile/${x[1]}">${x[0]}</h2></a>
+				<img src="./icon/${x[1]}" height=85%><br>
+				</div>`)}
 			</div>
 			<div class="supercenter" style="top: 71.5%"><h2 class="smaller gdButton"><a href="https://github.com/GDColon/GDBrowser">View on GitHub!</a></h2></div>
 			<img class="gdButton" src="../assets/arrow-left.png" width="60vh" style="position: absolute; top: 45%; right: 75%" onclick="page -= 1; loadCredits()">
-		</div>`)
+		</div>`);
+	creditsNode.insertAdjacentHTML('beforeEnd', `<div class="center supercenter" style="width: 80vh; height: 43%; pointer-events: none;">
+	<img class="closeWindow gdButton" src="../assets/close.png" height="25%" style="position: absolute; top: -24%; left: -7vh; pointer-events: all;" onclick="creditsNode.style.display = 'none'; page = 1;"></div>`);
+	document.addEventListener('keydown', function(k) {
+		if (creditsNode.style.display == "none") return;
+		if (k.code == "ArrowLeft" && page > 1) { //left
+			page -= 1; loadCredits();
+		}
 
-	res.contributors.forEach((x, y) => {
-		$('#githubbers').append(`<div class="githubChad">
-				<h2 class="gdButton smaller"><a href="./profile/${x[1]}">${x[0]}</h2></a>
-				<img src="./icon/${x[1]}" height=85%><br>
-				</div>`)
-	})
-
-	$('#credits').append(`<div class="center supercenter" style="width: 80vh; height: 43%; pointer-events: none;">
-	<img class="closeWindow gdButton" src="../assets/close.png" height="25%" style="position: absolute; top: -24%; left: -7vh; pointer-events: all;" onclick="$('#credits').hide(); page = 1;"></div>`)
-
-	$(document).keydown(function(k) {
-
-	if ($('#credits').is(':hidden')) return
-
-    if (k.which == 37 && page > 1) { //left
-		page -= 1; loadCredits();
-	}
-	
-	if (k.which == 39 && page < res.credits.length + 1) { //right
-		page += 1; loadCredits();
-	}
-	
+		if (k.code == "ArrowRight" && page < res.credits.length + 1) { //right
+			page += 1; loadCredits();
+		}
+	}, {passive: true})
 });
-})
 
 </script>

--- a/html/home.html
+++ b/html/home.html
@@ -79,9 +79,9 @@ function loadCredits() {
 	for (let el of document.querySelectorAll('.subCredits')) {
 		el.style.display = "none";
 		if (el.id == "credits"+page)
-			el.style.display = "block";
+			el.style.display = 'block';
 	}
-	document.querySelector('#credits').style.display = "block";
+	document.querySelector('#credits').style.display = 'block';
 }
 
 fetch(`./api/credits`).then(res => res.json()).then(res => {

--- a/html/iconkit.html
+++ b/html/iconkit.html
@@ -12,7 +12,7 @@
     </link>
 </head>
 <body class="iconscroll" style="background-image: linear-gradient(rgb(139, 139, 139), rgb(100, 100, 100));">
-<div class="center hidden"><br>
+<div class="center"><br>
     <img id="iconkitlogo" src="../assets/iconkit.png" height=50px; style="margin: 7px 0;"><br><br>
     <img id="loading" src="../assets/loading.png" class="spin" height=95px; style="margin: auto auto 25px auto">
     <img id="result" src="../icon/icon" download="icon.png">
@@ -40,13 +40,10 @@
     
 </div>
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
-<script type="text/javascript" src="https://unpkg.com/imagesloaded@4/imagesloaded.pkgd.min.js"></script>
 <script type="text/javascript">
 
-$('#loading').hide();
-$('.hidden').show();
+document.querySelector('#loading').style.display = 'none';
+for (let el of document.querySelectorAll('.hidden')) el.style.display = 'block';
 
 let mobile =  /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent)
 let forms = ['cube', 'ship', 'ball', 'ufo', 'wave', 'robot', 'spider']
@@ -58,159 +55,147 @@ let selectedCol1 = 0
 let selectedCol2 = 3
 let enableGlow = 0
 
-let imagesLoaded = 0
-let totalLoaded = 0
-
 function capitalize(str) {return str[0].toUpperCase() + str.substr(1)}
 
 if (mobile) {
-    $('#logo').attr('width', '80%');
+  document.querySelector('#logo').setAttribute('width', '80%');
 }
 
-forms.forEach(form => {$("#iconTabs").append(`<button form="${form}" class="blankButton iconTabButton"><img src="../iconkitbuttons/${form}_off.png" width=50px></button>`)})
-$("#iconTabs").append(`<button class="blankButton glowToggle" id="glowbtn"><img id="glow" src="../iconkitbuttons/streak_off.png" width=50px></button>`)
+document.querySelector("#iconTabs").insertAdjacentHTML('beforeEnd', forms.map(form => `<button form="${form}" class="blankButton iconTabButton"><img src="../iconkitbuttons/${form}_off.png" width=50px></button>`).join(''))
+document.querySelector("#iconTabs").insertAdjacentHTML('beforeEnd', `<button class="blankButton glowToggle" id="glowbtn"><img id="glow" src="../iconkitbuttons/streak_off.png" width=50px></button>`)
 
-forms.forEach(form => {$("#iconKitParent").append(`<div id="${form}s"></div>`)})
+forms.forEach(form => {document.querySelector("#iconKitParent").insertAdjacentHTML('beforeEnd', `<div id="${form}s"></div>`)})
 
 fetch('./api/icons').then(res => {
     return (res.json())})
     .then(iconArray => {
 
-        function filterIcon(name) { return iconArray.filter(x => x.startsWith(name)).sort(function (a,b) {return a.replace(/[^0-9]/g, "") - b.replace(/[^0-9]/g, "");})}
+      function filterIcon(name) { return iconArray.filter(x => x.startsWith(name)).sort(function (a,b) {return a.replace(/[^0-9]/g, "") - b.replace(/[^0-9]/g, "");})}
 
-        function appendIcon(form, formName) {
+      function appendIcon(form, formName) {
 
-        imagesLoaded = 0; totalLoaded = 0
-        $('#' + formName + 's').append('<br>')
+        document.querySelector('#' + formName + 's').insertAdjacentHTML('beforeEnd', '<br>')
 
         form.forEach(function (i, p) {
-        if (p != 0 && p % 12 == 0) $('#' + formName + 's').append('<br>')
-        $('#' + formName + 's').append(`<button num="${p + 1}" form="${formName}" class="blankButton iconButton" id="${formName}-${p + 1}"><img src="../gdicon/${i}" width="50px" title="${capitalize(formName)} ${p + 1}"></button>`)})
-        $('#' + formName + 's').imagesLoaded(function() {
-        }).progress(function() {
-        imagesLoaded += 1;
-        totalLoaded = imagesLoaded / $('#' + formName + 's').find('img').length * 100
-        $('#iconloading').css('width', `${totalLoaded}%`)
-        })}
+        if (p != 0 && p % 12 == 0) document.querySelector('#' + formName + 's').insertAdjacentHTML('beforeEnd', '<br>')
+        document.querySelector('#' + formName + 's').insertAdjacentHTML('beforeEnd', `<button num="${p+1}" form="${formName}" class="blankButton iconButton" id="${formName}-${p + 1}"><img src="../gdicon/${i}" width="50px" title="${capitalize(formName)} ${p + 1}"></button>`)})
+      }
 
-        let cubes = filterIcon('cube'); 
-        cubes.push(cubes.shift())
+      let cubes = filterIcon('cube'); 
+      cubes.push(cubes.shift());
+      appendIcon(cubes, 'cube');
 
-        $('body').imagesLoaded(function () {
-            appendIcon(cubes, "cube")
-            $('[num="1"][form="cube"]').addClass('iconSelected');
-        })
+      filterIcon('color').forEach(function (i, p) {
+        document.querySelector('#col1').insertAdjacentHTML('beforeEnd', `<button col=${p} class="blankButton color1" title="Color ${p}" id="col1-${p}"><img src="../gdicon/color_${p}.png" width=50px></button>`)
+        document.querySelector('#col2').insertAdjacentHTML('beforeEnd', `<button col=${p} class="blankButton color2" title="Color ${p}" id="col2-${p}"><img src="../gdicon/color_${p}.png" width=50px></button>`)
+      })
 
-        filterIcon('color').forEach(function (i, p) {
-           $('#col1').append(`<button col=${p} class="blankButton color1" title="Color ${p}" id="col1-${p}"><img src="../gdicon/color_${p}.png" width=50px></button>`)
-           $('#col2').append(`<button col=${p} class="blankButton color2" title="Color ${p}" id="col2-${p}"><img src="../gdicon/color_${p}.png" width=50px></button>`)})
+      document.querySelector('#col1').insertAdjacentHTML('beforeEnd', "<span style='min-width: 10px'></span>")
+      document.querySelector('#col2').insertAdjacentHTML('beforeEnd', "<span style='min-width: 10px'></span>")
+      document.querySelector('.color1[col="0"]').classList.add('iconSelected');
+      document.querySelector('.color2[col="3"]').classList.add('iconSelected');
 
-       $('#col1').append("<span style='min-width: 10px'></span>")
-       $('#col2').append("<span style='min-width: 10px'></span>")
+      for (let el of document.querySelectorAll('.iconTabButton')) el.addEventListener('click', function () {
 
-        $('.color1[col="0"]').addClass('iconSelected');
-        $('.color2[col="3"]').addClass('iconSelected');
-
-        $(document).on('click', '.iconTabButton', function () {
-
-        var form = $(this).attr('form')
+        var form = el.getAttribute('form')
         var forms = '#' + form + 's'
 
         currentForm = form
 
-        $('.iconTabButton').each(function(x, y) {
-        $(this).children().first().attr('src', $(this).children().first().attr('src').replace('_on', '_off'))})
+        for (let el of document.querySelectorAll('.iconTabButton')) {
+          el.firstChild.setAttribute('src', el.firstChild.getAttribute('src').replace('_on', '_off'));
+        }
+        var img = el.firstChild;
+        img.setAttribute('src', img.getAttribute('src').replace('_off', '_on'));
 
-        var img = $(this).children().first()
-        img.attr('src', img.attr('src').replace('_off', '_on'));
+        for (let el of document.querySelector('#iconKitParent').children) {
+          if (el.id != 'iconprogressbar') el.style.display = 'none';
+        }
+        if (!document.querySelector(forms) || document.querySelector(forms).innerHTML == "") appendIcon(filterIcon(form), form)
+        document.querySelector(forms).style.display = 'block';
+      })
 
-        $('#iconKitParent').each(function(x, y) {
-        $(this).children().not('#iconprogressbar').hide()})
-
-        if ($(forms).html() == "") appendIcon(filterIcon(form), form)
-        $(forms).show()
-        })
-
-        $('#iconTabs').find('.iconTabButton').first().children().first().attr('src', $('.iconTabButton').first().children().first().attr('src').replace('_off', '_on'))
+    for (let el of document.querySelectorAll('.color1')) el.addEventListener('click', function () {
+      for (let el of document.querySelectorAll(".color1")) el.classList.remove("iconSelected");
+      el.classList.add('iconSelected');
+      selectedCol1 = el.getAttribute('col');
+    })
+    for (let el of document.querySelectorAll('.color2')) el.addEventListener('click', function () {
+      for (let el of document.querySelectorAll(".color2")) el.classList.remove("iconSelected");
+      el.classList.add('iconSelected');
+      selectedCol2 = el.getAttribute('col');
     })
 
-    $(document).on('click', '.glowToggle', function () {
-
-    if (enableGlow) {
-        $("#glow").attr('src', $("#glow").attr('src').replace('_on', '_off'))
-        enableGlow = 0;
-    }
-
-    else {
-        $("#glow").attr('src', $("#glow").attr('src').replace('_off', '_on'))
-        enableGlow = 1;
-    }
-
+    document.querySelector("#generateIcon").addEventListener('click', function () {
+      document.querySelector("#loading").style.display = 'block';
+      document.querySelector("#result").style.display = 'none';
+      document.querySelector("#result").setAttribute('src', `../icon/icon?icon=${selectedIcon}&form=${selectedForm}&col1=${selectedCol1}&col2=${selectedCol2}&glow=${enableGlow}`)
+      document.querySelector("#downloadLink").setAttribute('href', `../icon/icon?icon=${selectedIcon}&form=${selectedForm}&col1=${selectedCol1}&col2=${selectedCol2}&glow=${enableGlow}`)
     })
 
-    $(document).on('click', '.iconButton', function () {
-    $(".iconButton").removeClass("iconSelected");
-    $(this).addClass('iconSelected');
-    selectedIcon = $(this).attr('num');
-    selectedForm = $(this).attr('form');
-    if (selectedIcon == 143) selectedIcon = 0;
+    document.querySelector('#result').addEventListener('load', function() {
+      document.querySelector("#loading").style.display = 'none';
+      document.querySelector('#result').style.removeProperty('display');
+        if (enableGlow == 1) document.querySelector("#gdfloor").style.marginTop = '-3px'
+        else document.querySelector("#gdfloor").style.marginTop = '0px';
     })
 
-    $(document).on('click', '.color1', function () {
-    $(".color1").removeClass("iconSelected");
-    $(this).addClass('iconSelected');
-    selectedCol1 = $(this).attr('col');
-    })
-
-    $(document).on('click', '.color2', function () {
-    $(".color2").removeClass("iconSelected");
-    $(this).addClass('iconSelected');
-    selectedCol2 = $(this).attr('col');
-    })
-
-    $("#generateIcon").click(function () {
-        $("#loading").show()
-        $("#result").hide()
-        $("#result").attr('src', `../icon/icon?icon=${selectedIcon}&form=${selectedForm}&col1=${selectedCol1}&col2=${selectedCol2}&glow=${enableGlow}`)
-        $("#downloadLink").attr('href', `../icon/icon?icon=${selectedIcon}&form=${selectedForm}&col1=${selectedCol1}&col2=${selectedCol2}&glow=${enableGlow}`)
-    })
-
-    $('#result').on('load', function() {
-        $("#loading").hide()
-        $("#result").show()
-        if (enableGlow == 1) $("#gdfloor").css('margin-top', '-3px')
-        else $("#gdfloor").css('margin-top', '0px')
-    })
-
-    $("#fetchUser").click(function () {
+    document.querySelector("#fetchUser").addEventListener('click', function () {
         
         let user = prompt(`Enter a player's username to get their ${currentForm == "ufo" ? "UFO" : currentForm}!\n(Form will depend on selected tab)\n`)
         if (!user) return;
 
         let iconURL = `../icon/${user}?form=${currentForm}`
-        $("#loading").show()
-        $("#result").hide()
-        $("#result").attr('src', iconURL)
-        $("#downloadLink").attr('href', iconURL)
-        $('#glow').attr('src', '../iconkitbuttons/streak_off.png')
+        document.querySelector("#loading").style.display = 'block'
+        document.querySelector("#result").style.display = 'hidden';
+        document.querySelector("#result").setAttribute('src', iconURL)
+        document.querySelector("#downloadLink").setAttribute('href', iconURL)
+        document.querySelector('#glow').setAttribute('src', '../iconkitbuttons/streak_off.png')
         enableGlow = 0
 
         fetch('../api/profile/' + user).then(res => res.json())
         .then(info => {
-            $(`#${currentForm}-${info.icon}`).trigger('click')
-            $(`#col1-${info.col1}`).trigger('click')
-            $(`#col2-${info.col2}`).trigger('click')
-            if (info.glow)$('#glowbtn').trigger('click')
+          document.querySelector(`#${currentForm}-${info.icon}`).click()
+          document.querySelector(`#col1-${info.col1}`).click()
+          document.querySelector(`#col2-${info.col2}`).click()
+            if (info.glow) document.querySelector('#glowbtn').click()
         })
-})
+      })
+      for (let el of document.querySelectorAll('.glowToggle')) el.addEventListener('click', function () {
+        if (enableGlow) {
+            document.querySelector("#glow").setAttribute('src', document.querySelector("#glow").getAttribute('src').replace('_on', '_off'))
+            enableGlow = 0;
+        }
 
+        else {
+            document.querySelector("#glow").setAttribute('src', document.querySelector("#glow").getAttribute('src').replace('_off', '_on'))
+            enableGlow = 1;
+        }
+
+        })
+        document.addEventListener('click', function (e) {
+          let el = e.target.closest('.iconButton');
+          if (!el) return;
+          for (let el of document.querySelectorAll(".iconButton")) el.classList.remove("iconSelected");
+          el.classList.add('iconSelected');
+          selectedIcon = el.getAttribute('num');
+          selectedForm = el.getAttribute('form');
+          if (selectedIcon == 143) selectedIcon = 0;
+        })
+    })
 document.getElementById("downloadIcon").onmousedown = function(event) {
-    if (event.which == 3) {
+    if (event.button == 2) {
         alert("URL copied to clipboard!");
-        var temp = $("<input>");
-          $("body").append(temp);
-          temp.val('https://gdbrowser.com' + $('#result').attr('src').slice(2)).select();
-          document.execCommand("copy"); temp.remove();
+        var temp = document.createElement("<div>"),
+          sel = window.getSelection(),
+          r = document.createRange();
+        temp.textContent = 'https://gdbrowser.com' + document.querySelector('#result').getAttribute('src').slice(2)
+        document.body.append(temp);
+        r.selectNodeContents(temp);
+        sel.removeAllRanges();
+        sel.addRange(r);
+        document.execCommand("copy");
+        temp.parentNode.removeChild(temp);
     }
 }
 
@@ -219,11 +204,10 @@ function backButton() {
 	window.location.href = "../../../../../"
 }
 
-$(document).keydown(function(k) {
-	if (k.keyCode == 27) { //esc
+document.addEventListener('keydown', function(k) {
+	if (k.code == 'Escape') { //esc
 		k.preventDefault()
-		$('#backButton').trigger('click')
+		document.querySelector('#backButton').click()
 	}
-});
-    
+}, {passive: true});
 </script>

--- a/html/leaderboard.html
+++ b/html/leaderboard.html
@@ -28,7 +28,7 @@
 		<div class="fancybox bounce center supercenter">
 			<h2 class="smaller center" style="font-size: 5.5vh">Leaderboard Info</h2>
 			<p class="bigger center" id="infoText" style="line-height: 5vh; margin-top: 1.5vh"></p>
-			<img src="../assets/ok.png" width=20%; class="gdButton center" onclick="$('.popup').hide()">
+			<img src="../assets/ok.png" width=20%; class="gdButton center" onclick="for (let el of document.querSelectorAll('.popup')) el.style.display = 'none'">
 		</div>
 	</div>
 
@@ -51,7 +51,7 @@
 	</div>
 
 	<div style="position:absolute; top: 2.5%; right: 2%; width: 10%; text-align: right;">
-		<img class="gdButton" src="../assets/smallinfo.png" width="32%" onclick="$('#infoDiv').show()">
+		<img class="gdButton" src="../assets/smallinfo.png" width="32%" onclick="document.querySelector('#infoDiv').style.display = 'block'">
 	</div>
 
 	<div class="supercenter" id="loading" style="height: 10%; top: 47%; display: none;">
@@ -61,9 +61,6 @@
 </div>
 
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.9/jquery.lazy.min.js"></script>
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.9/jquery.lazy.plugins.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script type="text/javascript" src="https://asvd.github.io/dragscroll/dragscroll.js"></script>
 <script>
@@ -74,19 +71,19 @@ let top250Text =
 `The <g>Top 250<> leaderboard contains the <g>top 250 players<>, sorted by <y>star<> value. However, due to <o>hackers<> flooding the leaderboard, this leaderboard has been <b>frozen<> for well over 2 years and displays <o>very outdated information<>.`
 
 let accurateText =
-`The <g>Accurate Leaderboard<> is a highly accurate, hacker-proof leaderboard with <y>proper stats and positioning<> (unlike the regular one). It is managed by <b>SMJSGaming, XShadowWizardX, Pepper360, Octeract<>, and many many other helpers. You can check out their interactive <a target="_blank" href="https://docs.google.com/spreadsheets/d/10lbPnDYJXhbtlA0ls0cGjjX_osFSG559IDrTbhgPHvc"><font color="aqua" style="text-decoration: underline">leaderboard spreadsheet here<></a>.`
+`The <g>Accurate Leaderboard<> is a highly accurate, hacker-proof leaderboard with <y>proper stats and positioning<> (unlike the regular one). It is managed by <b>SMJSGaming, XShadowWizardX, Pepper360, Octeract<>, and many many other helpers. You can check out their interactive <a target="_blank" href="https://docs.google.com/spreadsheets/d/10lbPnDYJXhbtlA0ls0cGjjX_osFSG559IDrTbhgPHvc"><span style="text-decoration: underline;color:aqua">leaderboard spreadsheet here<></a>.`
 
 let creatorText = 
 `The <g>Creators Leaderboard<> is sorted by <g>creator points<>, rather than stars. A player's <g>creator points<> (CP) is calculated by counting their number of <y>star rated<> levels, plus an extra point for every level that has been <b>featured<>, plus an additional point for <o>epic rated<> levels.`
 
 function infoText(text) {
 	let tweaked = text
-	.replace(/<g>/g, '<font color="#4CDA5B">')
-	.replace(/<b>/g, '<font color="#60ABEF">')
-	.replace(/<y>/g, '<font color="yellow">')
-	.replace(/<o>/g, '<font color="orange">')
-	.replace(/<>/g, '</font>')
-	$('#infoText').html(tweaked)
+	.replace(/<g>/g, '<span style="color:#4CDA5B">')
+	.replace(/<b>/g, '<span style="color:#60ABEF">')
+	.replace(/<y>/g, '<span style="color:yellow">')
+	.replace(/<o>/g, '<span style="color:orange">')
+	.replace(/<>/g, '</span>')
+	document.querySelector('#infoText').innerHTML = tweaked;
 }
 
 infoText(accurateText)
@@ -96,15 +93,12 @@ function leaderboard() {
 
 	if (loading == true) return;
 
-	$('#searchBox').html(`<div style="height: 4.5%"></div>`)
+	document.querySelector('#searchBox').innerHTML = `<div style="height: 4.5%"></div>`
 	loading = true;
-	$('#loading').show()
+	document.querySelector('#loading').style.display = 'block';
 
 	fetch(`../api/leaderboard?count=250&${type}`).then(res => res.json()).then(res => {
-
-		res.forEach((x, y) => {
-
-		$('#searchBox').append(`<div class="searchresult leaderboardSlot">
+    document.querySelector('#searchBox').insertAdjacentHTML('beforeEnd', res.map((x, y) => `<div class="searchresult leaderboardSlot">
 			<h2 class="small inline gdButton" style="margin-top: 1.5%"><a href="../profile/${x.username}">${x.username}</a></h2>
 			<h3 class="inline sideSpace" style="font-size: 4.5vh">${x.stars} <img class="valign" src="../assets/star.png"
 					style="cursor: help; height: 19%; transform: translate(-25%, -10%);" title="Stars"></h3>
@@ -123,15 +117,20 @@ function leaderboard() {
 					style="margin-bottom: 0%; transform:scale(1.1)">
 				<h2 class="small" style="margin-top: 2%">${x.rank}</h2>
 			</div>
-		</div>`)
-		})
+		</div>`).join(''))
 
-		$('#searchBox').append('<div style="height: 4.5%"></div>')
+		document.querySelector('#searchBox').insertAdjacentHTML('beforeEnd', '<div style="height: 4.5%"></div>')
 		loading = false;
-		$('#loading').hide();
-		$('.lazyLoad').Lazy({
-			appendScroll: '#searchBox'
-		});
+		document.querySelector('#loading').style.display = 'none';
+	  for (let el of document.querySelectorAll('.lazyLoad')) {
+      let onUpdateDim = function() {
+        if (!el.src && el.offsetTop < window.innerHeight + window.pageYOffset + 300)
+          el.src = el.getAttribute('data-src');
+      }
+      window.addEventListener('resize', onUpdateDim, {passive: true});
+      window.addEventListener('scroll', onUpdateDim, {passive: true});
+      onUpdateDim();
+    }
 	})
 
 }
@@ -139,37 +138,37 @@ function leaderboard() {
 	let type = "accurate"
 	leaderboard()
 
-	$('#topTabOff').click(function() {
+	document.querySelector('#topTabOff').addEventListener('click', function() {
 		if (type == "top" || loading) return;
 		type = "top"
 		leaderboard()
-		$('.leaderboardTab').hide();
-		$('#topTabOn').show()
-		$('#accurateTabOff').show()
-		$('#creatorTabOff').show()
+		for (let el of document.querySelectorAll('.leaderboardTab')) el.style.display = 'none';
+		document.querySelector('#topTabOff').style.display = 'block';
+		document.querySelector('#accurateTabOff').style.display = 'block';
+		document.querySelector('#creatorTabOn').style.display = 'block';
 		infoText(top250Text)
-	})
+	}, {passive: true})
 
-	$('#accurateTabOff').click(function() {
+	document.querySelector('#accurateTabOff').addEventListener('click', function() {
 		if (type == "accurate" || loading) return;
 		type = "accurate"
 		leaderboard()
-		$('.leaderboardTab').hide();
-		$('#topTabOff').show()
-		$('#accurateTabOn').show()
-		$('#creatorTabOff').show()
+		for (let el of document.querySelectorAll('.leaderboardTab')) el.style.display = 'none';
+		document.querySelector('#topTabOff').style.display = 'block';
+		document.querySelector('#accurateTabOff').style.display = 'block';
+		document.querySelector('#creatorTabOn').style.display = 'block';
 		infoText(accurateText)
-	})
+	}, {passive: true})
 
-	$('#creatorTabOff').click(function() {
+	document.querySelector('#creatorTabOff').addEventListener('click', function() {
 		if (type == "creator" || loading) return;
 		type = "creator"
 		leaderboard()
-		$('.leaderboardTab').hide();
-		$('#topTabOff').show()
-		$('#accurateTabOff').show()
-		$('#creatorTabOn').show()
+		for (let el of document.querySelector('.leaderboardTab')) el.style.display = 'none';
+		document.querySelector('#topTabOff').style.display = 'block';
+		document.querySelector('#accurateTabOff').style.display = 'block';
+		document.querySelector('#creatorTabOn').style.display = 'block';
 		infoText(creatorText)
-	})
+	}, {passive: true})
 
 </script>

--- a/html/level.html
+++ b/html/level.html
@@ -117,17 +117,17 @@
 	</div>
 
 	<div class="levelButtons" style="position:absolute; top: 46%; right: 3.5%; transform: translateY(-50%); height: 75%;">
-		<img class="gdButton sideButton" id="saveButton" src="../assets/plus.png" onclick="$('#saveDiv').show(); saveLevel()"><br>
-		<img class="gdButton sideButton" id="infoButton"  src="../assets/info.png" onclick="$('#infoDiv').show()"><br>
+		<img class="gdButton sideButton" id="saveButton" src="../assets/plus.png" onclick="document.querySelector('#saveDiv').style.display = 'block'; saveLevel()"><br>
+		<img class="gdButton sideButton" id="infoButton"  src="../assets/info.png" onclick="document.querySelector('#infoDiv').style.display = 'block'"><br>
 		<a href="./comments/[[ID]]"><img class="gdButton sideButton" src="../assets/comment.png"></a><br>
 		<a href="./analyze/[[ID]]"><img class="gdButton sideButton" src="../assets/edit.png"></a><br>
-		<img class="gdButton sideButton outOfOrder" id="scoreButton" src="../assets/leaderboard.png" onclick="$('#scoreDiv').show()"><br>
+		<img class="gdButton sideButton outOfOrder" id="scoreButton" src="../assets/leaderboard.png" onclick="document.querySelector('#scoreDiv').style.display = 'block'"><br>
 	</div>
 
 	<div style="position:absolute; top: 2%; left: 1.5%; width: 10%; height: 25%; pointer-events: none">
 		<img class="gdButton yesClick" id="backButton" src="../assets/back.png" height="30%" onclick="backButton()">
 	</div>
-	<div id="copied" style="display: none;">
+	<div id="copied">
 		<div class="copied center noClick" style="position:absolute; top: 36%; left: 50%; transform: translate(-50%,-50%); width: 80vh">
 			<h1 class="smaller noSelect">ID copied to clipboard</h1>
 		</div>
@@ -136,82 +136,105 @@
 </div>
 
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script>
-
-if (window.location.href.endsWith('?download')) $('#infoDiv').show()
+if (window.location.href.endsWith('?download')) document.querySelector('#infoDiv').style.display = 'block';
 
 	let freeze = false;
-	$('#playButton').click(function() {
-	if (!($('#copied').is(':animated'))) $('#copied').stop().fadeIn(200).delay(500).fadeOut(500)
-	var temp = $("<input>");
-    $("body").append(temp);
-    temp.val('[[ID]]').select();
-    document.execCommand("copy"); temp.remove()})
-$('.closeWindow').click(function() {if (!freeze) $(".popup").attr('style', 'display: none;')})
+	document.querySelector('#playButton').addEventListener('click', function() {
+    let copied = document.querySelector('#copied');
+    if (!copied.classList.contains('transitioning')) {
+      copied.classList.add('transitioning');
+      setTimeout(() => copied.classList.remove('transitioning'), 700);
+    }
+    var temp = document.createElement('div');
+    temp.textContent = '[[ID]]';
+    document.body.appendChild(temp);
+    let selectionRange = document.createRange();
+    selectionRange.selectNodeContents(temp);
+    let selection = getSelection();
+    selection.removeAllRanges();
+    selection.addRange(selectionRange);
+    document.execCommand("copy");
+    document.body.removeChild(temp);
+  }, {passive: true})
+for (let el of document.querySelectorAll('.closeWindow'))
+  el.addEventListener('click', function() {
+    if (!freeze) {
+      for (let el of document.querySelectorAll(".popup"))
+        el.style.display = 'none';
+    }
+  }, {passive: true})
 
-$('#difficultytext').html('[[DIFFICULTY]]'.replace(' ', "<br>"))
+document.querySelector('#difficultytext').innerHTML = '[[DIFFICULTY]]'.replace(' ', "<br>");
 
-$('#levelInfo').html($('#levelInfo').html()
-	.replace('[[ORIGINALINFO]]', [[COPIEDID]] ==  "0" ? "" : `<br>Original: <a class="youCanClickThis" href="/[[COPIEDID]]"><font color="aqua">[[COPIEDID]]</font></a>`)
-	.replace('[[OBJECTINFO]]', '[[OBJECTS]]' ==  "0" ? "" : `<br>Objects: <font color="yellow">[[OBJECTS]]</font>`)
-	.replace('[[REQUESTED]]', [[STARSREQUESTED]] ==  "0" ? "" : `<br>Stars Requested: <font color="yellow">[[STARSREQUESTED]]</font>`))
+document.querySelector('#levelInfo').innerHTML = document.querySelector('#levelInfo').innerHTML
+	.replace('[[ORIGINALINFO]]', [[COPIEDID]] ==  "0" ? "" : `<br>Original: <a class="youCanClickThis" href="/[[COPIEDID]]"><span style="color:aqua">[[COPIEDID]]</span></a>`)
+	.replace('[[OBJECTINFO]]', '[[OBJECTS]]' ==  "0" ? "" : `<br>Objects: <span style="color:yellow">[[OBJECTS]]</span>`)
+	.replace('[[REQUESTED]]', [[STARSREQUESTED]] ==  "0" ? "" : `<br>Stars Requested: <span style="color:yellow">[[STARSREQUESTED]]</span>`);
 
 if (!'[[UPLOADED]]'.startsWith('[')) {
-	$('#levelInfo').html($('#levelInfo').html()
-	.replace('[[PASS]]', `<br>Password: <font color="orange">${[[PASSWORD]] == 0 ? "No copy" : [[PASSWORD]] == 1 ? "Free copy" : [[PASSWORD]]}</font>`)
-	.replace('[[LOWDETAIL]]', `<br>Low Detail: <font color="orange">${[[LDM]] ? "Yes" : "No"}</font>`)
-	.replace('[[UPLOAD]]', '[[UPLOADED]]' == "0" ? "" : `<br>Uploaded: <font color="orange">[[UPLOADED]]</font>`)
-	.replace('[[UPDATE]]', '[[UPDATED]]' == "0" ? "" : `<br>Updated: <font color="orange">[[UPDATED]]</font>`))}
-
+	document.querySelector('#levelInfo').innerHTML = document.querySelector('#levelInfo').innerHTML
+	.replace('[[PASS]]', `<br>Password: <span style="color:orange">${[[PASSWORD]] == 0 ? "No copy" : [[PASSWORD]] == 1 ? "Free copy" : [[PASSWORD]]}</span>`)
+	.replace('[[LOWDETAIL]]', `<br>Low Detail: <span style="color:orange">${[[LDM]] ? "Yes" : "No"}</span>`)
+	.replace('[[UPLOAD]]', '[[UPLOADED]]' == "0" ? "" : `<br>Uploaded: <span style="color:orange">[[UPLOADED]]</span>`)
+  .replace('[[UPDATE]]', '[[UPDATED]]' == "0" ? "" : `<br>Updated: <span style="color:orange">[[UPDATED]]</span>`)
+}
 else {
-	$('#levelInfo').html($('#levelInfo').html()
+	document.querySelector('#levelInfo').innerHTML = document.querySelector('#levelInfo').innerHTML
 	.replace('[[PASS]]', "")
 	.replace('[[LOWDETAIL]]', "")
 	.replace('[[UPLOAD]]', "")
 	.replace('[[UPDATE]]', "") + 
-	`<br><a class="youCanClickThis" href="/[[ID]]?download"><font color="aqua">Download additional info</font></a>`
-	)}
+	`<br><a class="youCanClickThis" href="/[[ID]]?download"><span style="color:aqua">Download additional info</span></a>`  
+}
 
-if ([[COPIEDID]] == 0) $('#copiedBadge').hide()
-if (![[LARGE]]) $('#largeBadge').hide()
-if ([[ORBS]] == 0) $('.orbs').hide()
-if ([[STARS]] == 0) $('.stars').hide()
-if ([[DIAMONDS]] == 0 || !'[[DEMONLIST]]'.startsWith("[")) $('.diamonds').hide()
-
-if (!'[[DEMONLIST]]'.startsWith("[")) $('.demonList').show()
-else $('.demonList').remove()
+if ([[COPIEDID]] == 0) document.querySelector('#copiedBadge').style.display = 'none';
+if (![[LARGE]]) document.querySelector('#largeBadge').style.display = 'none';
+if ([[ORBS]] == 0) for (let el of document.querySelectorAll('.orbs')) el.style.display = 'none';
+if ([[STARS]] == 0) for (let el of document.querySelectorAll('.stars')) el.style.display = 'none';
+if ([[DIAMONDS]] == 0 || !'[[DEMONLIST]]'.startsWith("[")) for (let el of document.querySelectorAll('.diamonds')) el.style.display = 'none';
+const demonList = document.querySelectorAll('.demonList');
+if (!'[[DEMONLIST]]'.startsWith("[")) {for (let el of demonList) el.style.display = 'block';}
+else {for (let el of demonList) el.parentNode.removeChild(el)}
 
 
 if ("[[SONGID]]".startsWith("Level")) {
-	$('#songInfo').text('[[SONGID]]')
-	$('.songLink').hide()}
-
-if ("[[INVALIDSONG]]" == "true") $('.songLink').hide()
-if ("[[DISLIKED]]" == "true") $('#likeImg').attr('src', '../assets/dislike.png').css('transform', 'translateY(20%)')
+	document.querySelector('#songInfo').textContent = '[[SONGID]]';
+  for (let el of document.querySelectorAll('.songLink')) el.style.display = 'none'
+}
+if ("[[INVALIDSONG]]" == "true") for (let el of document.querySelectorAll('.songLink')) el.style.display = 'none'
+if ("[[DISLIKED]]" == "true") {
+  let likeImg = document.querySelector('#likeImg');
+  likeImg.setAttribute('src', '../assets/dislike.png');
+  likeImg.style.transform =' translateY(20%)';
+}
 
 let coinColor = [[VERIFIEDCOINS]] ? "silvercoin" : "browncoin"
-if ([[COINS]] > 0) $("#coins").append(`<img src="../assets/${coinColor}.png" height="5%">`)
-if ([[COINS]] > 1) $("#coins").append(`<img class="squeeze" src="../assets/${coinColor}.png" height="5%">`)
-if ([[COINS]] > 2) $("#coins").append(`<img class="squeeze" src="../assets/${coinColor}.png" height="5%">`)
+if ([[COINS]] > 0) document.querySelector("#coins").insertAdjacentHTML('beforeEnd', `<img src="../assets/${coinColor}.png" height="5%">`)
+if ([[COINS]] > 1) document.querySelector("#coins").insertAdjacentHTML('beforeEnd', `<img class="squeeze" src="../assets/${coinColor}.png" height="5%">`)
+if ([[COINS]] > 2) document.querySelector("#coins").insertAdjacentHTML('beforeEnd', `<img class="squeeze" src="../assets/${coinColor}.png" height="5%">`)
 
 if ("[[ACCOUNTID]]" == "0") {
-		$("#authorName").addClass("green").removeClass('gdButton')
-		$("#authorLink").removeAttr('href')
+    let cL = document.querySelector("#authorName").classList;
+    cL.add("green")
+    cL.remove('gdButton')
+		document.querySelector("#authorLink").removeAttribute('href')
 	}
 
-if (window.location.pathname == "/weekly") $('body').addClass('darkBG')
+if (window.location.pathname == "/weekly") document.querySelector('body').classList.add('darkBG')
 
 
-$(window).on('load', function() {
-
-	if ($('#songname')[0].scrollWidth > $('#songBox')[0].scrollWidth) {
-		let overflow = ($('#songname')[0].scrollWidth - $('#songBox')[0].scrollWidth) * 0.007
+window.onload = function() {
+  const songname = document.querySelector('#songname');
+  const songbox = document.querySelector('#songBox')
+	if (songname.scrollWidth > songbox.scrollWidth) {
+		let overflow = (songname.scrollWidth - songbox.scrollWidth) * 0.007
 		if (overflow > 6) overflow = 3
-		$('#songname').addClass('smaller').css('font-size', (6 - (overflow)) + 'vh')
-		}
-});
+    songname.classList.toggle('smaller');
+    songname.style.fontSize = (6 - (overflow)) + 'vh';
+	}
+};
 
 
 let savedLevels = document.cookie.split('; ').find(x => x.startsWith('saved'))
@@ -219,7 +242,11 @@ let levelList = []
 let deleteMode = false;
 if (savedLevels) {
 	levelList = savedLevels.slice(6).split(',')
-	if (levelList.includes('[[ID]]')) $('#saveButton').attr('src', '../assets/delete.png').attr('onclick', '$("#deleteDiv").show()')
+	if (levelList.includes('[[ID]]')) {
+    const sB = document.querySelector('#saveButton');
+    sb.setAttribute('src', '../assets/delete.png');
+    sb.setAttribute('onclick', 'document.querySelector("#deleteDiv").style.display = "block"');
+  }
 }
 
 function saveLevel() {
@@ -232,5 +259,6 @@ function deleteLevel() {
 	location.reload()
 	freeze = true;
 }
+
 
 </script>

--- a/html/level.html
+++ b/html/level.html
@@ -243,15 +243,17 @@ let deleteMode = false;
 if (savedLevels) {
 	levelList = savedLevels.slice(6).split(',')
 	if (levelList.includes('[[ID]]')) {
-    const sB = document.querySelector('#saveButton');
-    sb.setAttribute('src', '../assets/delete.png');
-    sb.setAttribute('onclick', 'document.querySelector("#deleteDiv").style.display = "block"');
+    let sB = document.querySelector('#saveButton');
+    sB.setAttribute('src', '../assets/delete.png');
+    sB.setAttribute('onclick', 'document.querySelector("#deleteDiv").style.display = "block"');
   }
 }
 
 function saveLevel() {
 	let newCookie = savedLevels ? `${savedLevels.slice(6)},[[ID]]` : '[[ID]]'
-	document.cookie = `saved=${newCookie}; expires=Fri, 31 Dec 9999 23:59:59 GMT`
+  document.cookie = `saved=${newCookie}; expires=Fri, 31 Dec 9999 23:59:59 GMT`
+  location.reload();
+  freeze = true;
 }
 
 function deleteLevel() {

--- a/html/mappacks.html
+++ b/html/mappacks.html
@@ -29,21 +29,15 @@
 	
 </div>
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script>
 
 fetch('../api/mappacks').then(res => res.json()).then(packs => {
-	keys = Object.keys(packs)
-	keys.forEach(x => {
-		$('#packList').append(`
+  keys = Object.keys(packs);
+  document.querySelector('#packList').insertAdjacentHTML('beforeEnd', keys.map(x => `
 			<div class="mappack">
 			<a href="../search/${x}?mappack=1">
 			<img src="../difficulty/${packs[x][3]}.png" height="220%"><br>
-			<h3 class="gauntletText"">${x.replace("Pack", "<br>Pack")}</h3></div></a>`)
-	})
+			<h3 class="gauntletText"">${x.replace("Pack", "<br>Pack")}</h3></div></a>`).join(''));
 })
-
-
-
 </script>

--- a/html/profile.html
+++ b/html/profile.html
@@ -149,7 +149,7 @@ function appendComments() {
   document.querySelector('#statusDiv').innerHTML = `<div class="supercenter" id="loading" style="height: 12%; top: 62%;"><img class="spin noSelect" src="../assets/loading.png" height="105%"></div>`;
 
   if (page == 0) document.querySelector('#pageDown').style.display = 'none'
-  else document.querySelector('#pageDown').style.display = "block";
+  else document.querySelector('#pageDown').style.display.display = 'block';
 
   fetch(`../api/comments/[[ACCOUNTID]]?type=profile&page=${page}`).then(res => res.json()).then(res => {
 

--- a/html/profile.html
+++ b/html/profile.html
@@ -21,7 +21,7 @@
 				Private Messages: [[DMS]]<br>
 				Comment History: [[COMMENTS]]<br>
 			</p>
-			<img src="../assets/ok.png" width=20%; class="gdButton center" onclick="$('#settingsDiv').hide()">
+			<img src="../assets/ok.png" width=20%; class="gdButton center" onclick="document.querySelector('#settingsDiv').style.display = 'none'">
 		</div>
 	</div>
 
@@ -37,7 +37,7 @@
 		<img class="gdButton yesClick" id="backButton" src="../assets/back.png" height="30%" onclick="backButton()">
 	</div>
 
-	<div class="brownBox center supercenter" style="width: 135vh; height: 82%; margin-top: -0.7%">
+	<div class="brownBox center supercenter" style="width: 90vw; height: 82%; margin-top: -0.7%">
 
 		<h1 class="veryBig inline">
 			<img class="inline valign" id="modBadge1" style="display: none; height: 7%; margin-right: -6%; cursor:help" src="../assets/mod.png" title="[[USERNAME]] is a moderator!">	
@@ -69,13 +69,13 @@
 		</div>
 
 		<div class="center" style="margin: 2.5% auto;">
-			<img src="../assets/messages.png" height="10%" id="msgButton" class="sideSpace gdButton" onclick="$('#settingsDiv').show()">
-			<img src="../assets/friends.png" height="10%" id="friendButton" class="sideSpace gdButton" onclick="$('#settingsDiv').show()">
+			<img src="../assets/messages.png" height="10%" id="msgButton" class="sideSpace gdButton" onclick="document.querySelector('#settingsDiv').style.display = 'none'">
+			<img src="../assets/friends.png" height="10%" id="friendButton" class="sideSpace gdButton" onclick="document.querySelector('#settingsDiv').style.display = 'block'">
 		</div>
 
 		<!-- <img src="../assets/follow-off.png" class="gdButton" style="position: absolute; left: 0.5%; bottom: 1%; width: 6%"> -->
 		<a href="../search/[[USERNAME]]?user"><img src="../assets/levels.png" class="gdButton" style="position: absolute; right: 0.5%; bottom: 1%; width: 6%"></a>
-		<a id="commentA"><img src="../assets/comments.png" class="gdButton" id="commentButton" style="position: absolute; right: 0.5%; bottom: 50%; width: 6%" onclick="$('#settingsDiv').show()"></a>
+		<a id="commentA"><img src="../assets/comments.png" class="gdButton" id="commentButton" style="position: absolute; right: 0.5%; bottom: 50%; width: 6%" onclick="document.querySelector('#settingsDiv').style.display = 'none'"></a>
 
 		<div style="position: absolute; right: 0.5%; top: 0%; width: 6%">
 			<a id="youtube" style="display: none" target="_blank" href="https://youtube.com/channel/[[YOUTUBE]]"><img src="../assets/youtube.png" class="gdButton socialButton"></a>
@@ -100,87 +100,88 @@
 </div>
 
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script type="text/javascript" src="https://asvd.github.io/dragscroll/dragscroll.js"></script>
 
 <script>
 
-$('#collectibles').html($('#collectibles').html().split('0 <img class="valign" src="../assets/cp')[0])
-$('#modBadge[[MODERATOR]]').show()
-$('#globalrank[[RANK]]').hide()
+document.querySelector('#collectibles').innerHTML = document.querySelector('#collectibles').innerHTML.split('0 <img class="valign" src="../assets/cp')[0];
+let mod = document.querySelector('#modBadge[[MODERATOR]]');
+if (mod) mod.style.display = 'block';
+let rank = document.querySelector('#globalrank[[RANK]]');
+if (rank) rank.style.display = 'none';
 
-if (`[[YOUTUBE]]` != "null") $('#youtube').show()
-if (`[[TWITTER]]` != "null") $('#twitter').show()
-if (`[[TWITCH]]` != "null")  $('#twitch').show()
+if (`[[YOUTUBE]]` != "null") document.querySelector('#youtube').style.display = 'block';
+if (`[[TWITTER]]` != "null") document.querySelector('#twitter').style.display = 'block';
+if (`[[TWITCH]]` != "null")  document.querySelector('#twitch').style.display = 'block';
 
 let messages = "[[MESSAGES]]"
 let commenthistory = "[[COMMENTHISTORY]]"
 
-let reqMode = [[FRIENDREQUESTS]] ? "<font color='lime'>Enabled</font>" : "<font color='red'>Disabled</font>"
-let dmMode = messages == "all" ? "<font color='lime'>Public</font>" : messages == "friends" ? "<font color='yellow'>Friends Only</font>" : "<font color='red'>Disabled</font>"
-let commentMode = commenthistory == "all" ? "<font color='lime'>Public</font>" : commenthistory == "friends" ? "<font color='yellow'>Friends Only</font>" : "<font color='red'>Disabled</font>"
+let reqMode = [[FRIENDREQUESTS]] ? "<span style='color:lime'>Enabled</span>" : "<span style='color:red'>Disabled</span>"
+let dmMode = messages == "all" ? "<span style='color:lime'>Public</span>" : messages == "friends" ? "<span style='color:yellow'>Friends Only</span>" : "<span style='color:red'>Disabled</span>"
+let commentMode = commenthistory == "all" ? "<span style='color:lime'>Public</span>" : commenthistory == "friends" ? "<span style='color:yellow'>Friends Only</span>" : "<span style='colorred'>Disabled</span>"
 
-if (commenthistory == "friends") $('#commentButton').attr('src', '../assets/comments-yellow.png')
-else if (commenthistory == "off") $('#commentButton').attr('src', '../assets/comments-grey.png')
+if (commenthistory == "friends") document.querySelector('#commentButton').setAttribute('src', '../assets/comments-yellow.png')
+else if (commenthistory == "off") document.querySelector('#commentButton').setAttribute('src', '../assets/comments-grey.png')
 else {
-	$('#commentButton').attr('src', '../assets/comments.png').attr('onclick', '')
-	$('#commentA').attr('href', '../comments/[[USERNAME]]')
+  const cB = document.querySelector('#commentButton');
+  cB.setAttribute('src', '../assets/comments.png');
+  cB.setAttribute('onclick', '');
+	document.querySelector('#commentA').setAttribute('href', '../comments/[[USERNAME]]')
 }
 
-if (messages == "friends") $('#msgButton').attr('src', '../assets/messages-yellow.png')
-else if (messages == "off") $('#msgButton').attr('src', '../assets/messages-grey.png')
+if (messages == "friends") document.querySelector('#msgButton').setAttribute('src', '../assets/messages-yellow.png')
+else if (messages == "off") document.querySelector('#msgButton').setAttribute('src', '../assets/messages-grey.png')
 
-if (![[FRIENDREQUESTS]]) $('#friendButton').attr('src', '../assets/friends-grey.png')
+if (![[FRIENDREQUESTS]]) document.querySelector('#friendButton').setAttribute('src', '../assets/friends-grey.png')
 
-$('#userInfo').html($('#userInfo').html()
-.replace("[[REQS]]", reqMode)
-.replace("[[DMS]]", dmMode)
-.replace("[[COMMENTS]]", commentMode))
+document.querySelector('#userInfo').innerHTML = document.querySelector('#userInfo').innerHTML
+  .replace("[[REQS]]", reqMode)
+  .replace("[[DMS]]", dmMode)
+  .replace("[[COMMENTS]]", commentMode);
 
 function appendComments() {
 
-if (loadingComments) return;
-else loadingComments = true;
+  if (loadingComments) return;
+  else loadingComments = true;
 
-$('#statusDiv').html(`<div class="supercenter" id="loading" style="height: 12%; top: 62%;"><img class="spin noSelect" src="../assets/loading.png" height="105%"></div>`)
+  document.querySelector('#statusDiv').innerHTML = `<div class="supercenter" id="loading" style="height: 12%; top: 62%;"><img class="spin noSelect" src="../assets/loading.png" height="105%"></div>`;
 
-if (page == 0) $('#pageDown').hide()
-else $('#pageDown').show()
+  if (page == 0) document.querySelector('#pageDown').style.display = 'none'
+  else document.querySelector('#pageDown').style.display = "block";
 
-fetch(`../api/comments/[[ACCOUNTID]]?type=profile&page=${page}`).then(res => res.json()).then(res => {
+  fetch(`../api/comments/[[ACCOUNTID]]?type=profile&page=${page}`).then(res => res.json()).then(res => {
 
-	if (res.length != 10) $('#pageUp').hide()
-	else $('#pageUp').show()
+    if (res.length != 10) document.querySelector('#pageUp').style.display = 'none'
+    else document.querySelector('#pageUp').style.display = 'block';
 
-	if (res == "-1") return $('#loading').hide()
+    if (res == "-1") return document.querySelector('#loading').style.display = 'none';
 
-	res.forEach(x => {
-		$('#statusDiv').append(`
-			<div class="commentBG">
-				<div class="comment">
-					<h2>[[USERNAME]]</h2>
-					<div class="commentAlign">
-						<p class="commentText" style="color: ${"[[USERNAME]]" == "RobTop" ? "rgb(50, 255, 255)" : "[[MODERATOR]]" == "2" ? "rgb(75, 255, 75)" : "white"}">${x.content}</p>
-					</div>
-				</div>
-				<p class="commentDate">${x.date}</p>
-				<div class="commentLikes">
-					<img id="likeImg" class="inline" ${x.likes < 0 ? "style='transform: translateY(25%)'" : ""} src="../assets/${x.likes < 0 ? "dis" : ""}like.png" height=20% style="margin-right: 0.4%">
-					<h3 class="inline">${x.likes}</h3><br>
-				</div>
-			</div>`)
-	})
+    document.querySelector('#statusDiv').insertAdjacentHTML('beforeEnd', res.map(x => `
+      <div class="commentBG">
+        <div class="comment">
+          <h2>[[USERNAME]]</h2>
+          <div class="commentAlign">
+            <p class="commentText" style="color: ${"[[USERNAME]]" == "RobTop" ? "rgb(50, 255, 255)" : "[[MODERATOR]]" == "2" ? "rgb(75, 255, 75)" : "white"}">${x.content}</p>
+          </div>
+        </div>
+        <p class="commentDate">${x.date}</p>
+        <div class="commentLikes">
+          <img id="likeImg" class="inline" ${x.likes < 0 ? "style='transform: translateY(25%)'" : ""} src="../assets/${x.likes < 0 ? "dis" : ""}like.png" height=20% style="margin-right: 0.4%">
+          <h3 class="inline">${x.likes}</h3><br>
+        </div>
+      </div>`).join(''));
 
-	$('.commentText').each(function() {
-	if ($(this).text().length > 100) {
-	let overflow = ($(this).text().length - 100) * 0.01
-	$(this).css('font-size', (3.5 - (overflow)) + 'vh')
-	}
-});
-$('#loading').hide()
-})
-loadingComments = false;
+    for (let el of document.querySelectorAll('.commentText')) {
+      if (el.textContent.length > 100) {
+        let overflow = (el.textContent.length - 100) * 0.01
+        el.style.fontSize =  (3.5 - (overflow)) + 'vh';
+      }
+    };
+    document.querySelector('#loading').style.display = 'none';
+  })
+  loadingComments = false;
 }
 
 let page = 0

--- a/html/search.html
+++ b/html/search.html
@@ -34,7 +34,7 @@
 		<div class="fancybox bounce center supercenter" style="width: 35%; height: 28%">
 			<h2 class="smaller center" style="font-size: 5.5vh">Delete All</h2>
 			<p class="bigger center" style="line-height: 5vh; margin-top: 1.5vh;">
-				Delete all saved online levels?<br><font color="yellow">Levels will be cleared from your cookies.</font>
+				Delete all saved online levels?<br><span style="color:yellow">Levels will be cleared from your cookies.</span>
 			</p>
 			<img src="../assets/btn-cancel.png" height=25%; class="gdButton center closeWindow">
 			<img src="../assets/btn-delete.png" height=25%; id="purgeSaved" class="gdButton center sideSpaceB">

--- a/html/search.html
+++ b/html/search.html
@@ -21,11 +21,11 @@
 			<img class="closeWindow gdButton" src="../assets/close.png" height="25%" style="position: absolute; top: -13.5%; left: -6vh">
 
 			<div class="supercenter" style="left: 25%; top: 43%; height: 10%;">
-				<img class="gdButton" src="../assets/whitearrow-left.png" height="160%" onclick="$('#pageSelect').val(parseInt($('#pageSelect').val() || 0) - 1); $('#pageSelect').trigger('input');">
+				<img class="gdButton" src="../assets/whitearrow-left.png" height="160%" onclick="document.querySelector('#pageSelect').value = parseInt(document.querySelector('#pageSelect').value || 0) - 1;">
 			</div>
 		
 			<div class="supercenter" style="left: 75%; top: 43%; height: 10%;">
-				<img class="gdButton" src="../assets/whitearrow-right.png" height="160%" onclick="$('#pageSelect').val(parseInt($('#pageSelect').val() || 0) + 1); $('#pageSelect').trigger('input');">
+				<img class="gdButton" src="../assets/whitearrow-right.png" height="160%" onclick="document.querySelector('#pageSelect').value = parseInt(document.querySelector('#pageSelect').value || 0) + 1;">
 			</div>
 		</div>
 	</div>
@@ -64,7 +64,7 @@
 	</div>
 
 	<div style="text-align: right; position:absolute; top: 7.5%; right: 2%; height: 12%;">
-		<img src="../assets/magnify.png" height="55%" class="gdButton" style="margin-top: 5%" onclick="$('#pageDiv').show(); $('#pageSelect').focus().select()">
+		<img src="../assets/magnify.png" height="55%" class="gdButton" style="margin-top: 5%" onclick="document.querySelector('#pageDiv').style.display = 'block'; let ps = document.querySelector('#pageSelect'),sel=window.getSelection(),r=document.createRange(); ps.focus(); r.selectNode(ps); sel.removeAllRanges(); sel.addRange(r)">
 	</div>
 
 	<div style="position:absolute; top: 2%; left: 1.5%; width: 10%; height: 25%; pointer-events: none">
@@ -72,7 +72,7 @@
 	</div>
 
 	<div id="purge" style="position:absolute; bottom: 1%; right: -3%; width: 10%; display:none;">
-		<img class="gdButton" src="../assets/delete.png" width="60%" onclick="$('#purgeDiv').show()">
+		<img class="gdButton" src="../assets/delete.png" width="60%" onclick="document.querySelector('#purgeDiv').style.display = 'block'">
 	</div>
 
 	<div style="position: absolute; left: 7%; top: 45%; height: 10%;">
@@ -90,13 +90,12 @@
 </div>
 
 </body>
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script async type="text/javascript" src="../assets/sizecheck.js"></script>
 <script type="text/javascript" src="https://asvd.github.io/dragscroll/dragscroll.js"></script>
 <script>
 
-$('#pageDown').hide()
-$('#pageUp').hide()
+document.querySelector('#pageDown').style.display = 'hidden';
+document.querySelector('#pageUp').style.display = 'hidden';
 
 let accID;
 let path = location.pathname.replace('/search/', "")
@@ -112,30 +111,30 @@ let gauntlets = ["Fire", "Ice", "Poison", "Shadow", "Lava", "Bonus", "Chaos", "D
 function Append() {
 
 	loading = true;
-	$('#searchBox').html('<div style="height: 4.5%"></div>')
-	$('#pagenum').text('Page ' + (page + 1))
-	$('#pageSelect').val(page + 1)
-	$('#loading').show()
+	document.querySelector('#searchBox').innerHTML = '<div style="height: 4.5%"></div>'
+	document.querySelector('#pagenum').textContent = 'Page ' + (page + 1)
+	document.querySelector('#pageSelect').value = page + 1;
+	document.querySelector('#loading').style.display = 'block';
 
 	fetch(`../api/search/${accID || path}?page=${page}${window.location.search.replace("?", "&").replace("page", "nope")}`).then(res => res.json()).then(res => {
 
-	if (page == 0) $('#pageDown').hide()
-	else $('#pageDown').show()
+	if (page == 0) document.querySelector('#pageDown').style.display = 'none';
+	else document.querySelector('#pageDown').style.display = 'block';
 
-	if (res == '-1' || (res.length < 9 && type != "recent")) $('#pageUp').hide()
-	else $('#pageUp').show()
+	if (res == '-1' || (res.length < 9 && type != "recent")) document.querySelector('#pageUp').style.display = 'none'
+	else document.querySelector('#pageUp').style.display = 'block'
 
-	if (res == '-1') { $('#loading').hide(); return loading = false }
+	if (res == '-1') { document.querySelector('#loading').style.display = 'none'; return loading = false }
 
 	res.forEach((x, y) => {
 		let hasAuthor = (x.accountID != "0")
 		if (y == 0 && (type == 5 || typeof userMode == 'string')) {
-			$('#header').text(x.author + (x.author.toLowerCase().endsWith('s') ? "'" : "'s") + " levels")
-			document.title = $('#header').text()
+			document.querySelector('#header').textContent = x.author + (x.author.toLowerCase().endsWith('s') ? "'" : "'s") + " levels"
+			document.title = document.querySelector('#header').textContent
 			accID = x.authorID
 		}
 
-		$('#searchBox').append(`<div class="searchresult">
+		document.querySelector('#searchBox').insertAdjacentHTML('beforeEnd', `<div class="searchresult">
 			<h1 class="lessspaced">${x.name}</h1>
 			<h2 class="lessSpaced smaller inline ${hasAuthor ? "gdButton" : "green"}">${hasAuthor ? `<a href="../profile/${x.author}">By ${x.author}</a>` : `By ${x.author}`}</h2><h2 class="inline" style="margin-left: 1.5%; transform:translateY(30%)"> ${x.copiedID == '0' ? "" : '<img class="valign sideSpace" src="../assets/copied.png" height="12%">'}${x.large ? '<img class="valign sideSpaceD" src="../assets/large.png" height="12%">' : ''}</h2>
 			<h3 class="lessSpaced ${x.customSong == 0 ? "blue" : "whatIfItWasPurple"}" style="overflow: hidden;">${x.songName}</h3>
@@ -162,83 +161,83 @@ function Append() {
 		</div>`)
 	})
 
-	$('#searchBox').append('<div style="height: 4.5%"></div>')
-	$('#loading').hide()
+	document.querySelector('#searchBox').insertAdjacentHTML('beforeEnd', '<div style="height: 4.5%"></div>')
+	document.querySelector('#loading').style.display = 'none';
 	loading = false;
 })
 }
 
 Append()
 
-$('#pageUp').click(function() {page += 1; if (!loading) Append()})
-$('#pageDown').click(function() {page -= 1; if (!loading) Append()})
-$('#pageJump').click(function() {if (loading) return; page = parseInt(($('#pageSelect').val() || 1) - 1); Append()})
+document.querySelector('#pageUp').onclick = function() {page += 1; if (!loading) Append()};
+document.querySelector('#pageDown').onclick = function() {page -= 1; if (!loading) Append()}
+document.querySelector('#pageJump').onclick = function() {if (loading) return; page = parseInt((document.querySelector('#pageSelect').value || 1) - 1); Append()};
 
-if (type == 1 || type == 'mostdownloaded') $('#header').text("Most Downloaded")
-if (type == 2 || type == 'mostliked') $('#header').text("Most Liked")
-if (type == 3 || type == 'trending') $('#header').text("Trending Levels")
-if (type == 4 || type == 'recent') $('#header').text("Recent Levels")
-if (type == 6 || type == 'featured') $('#header').text("Featured")
-if (type == 7 || type == 'magic') $('#header').text("Magic Levels")
-if (type == 11 || type == 'awarded' || type == 'starred') $('#header').text("Awarded Levels")
-if (type == 16 || type == 'halloffame' || type == 'hof') $('#header').text("Hall of Fame")
-document.title = $('#header').text() || "Level Search"
-$('#meta-title').attr('content', $('#header').text() || "Level Search")
-if ($('#header').text()) $('#meta-desc').attr('content',  `View Geometry Dash's ${$('#header').text()}${$('#header').text() == "Hall of Fame" ? "" : "list"}!`)
+if (type == 1 || type == 'mostdownloaded') document.querySelector('#header').textContent = "Most Downloaded";
+if (type == 2 || type == 'mostliked') document.querySelector('#header').textContent = "Most Liked"
+if (type == 3 || type == 'trending') document.querySelector('#header').textContent = "Trending Levels"
+if (type == 4 || type == 'recent') document.querySelector('#header').textContent = "Recent Levels"
+if (type == 6 || type == 'featured') document.querySelector('#header').textContent = "Featured"
+if (type == 7 || type == 'magic') document.querySelector('#header').textContent = "Magic Levels"
+if (type == 11 || type == 'awarded' || type == 'starred') document.querySelector('#header').textContent = "Awarded Levels"
+if (type == 16 || type == 'halloffame' || type == 'hof') document.querySelector('#header').textContent = "Hall of Fame"
+document.title = document.querySelector('#header').textContent || "Level Search"
+document.querySelector('#meta-title').setAttribute('content', document.querySelector('#header').textContent || "Level Search")
+if (document.querySelector('#header').textContent) document.querySelector('#meta-desc').setAttribute('content', `View Geometry Dash's ${document.querySelector('#header').textContent}${document.querySelector('#header').textContent == "Hall of Fame" ? "" : "list"}!`)
 
 if (type == 'saved') {
-	$('#header').text("Saved Levels")
-	$('#purge').show()
+	document.querySelector('#header').textContent = "Saved Levels"
+	document.querySelector('#purge').style.display = 'block';
 	document.title = "Saved Levels"
-	$('#meta-title').attr('content', `Saved Levels`)
-	$('#meta-desc').attr('content',  `View your collection of saved Geometry Dash levels!`)
+	document.querySelector('#meta-title').setAttribute('content', `Saved Levels`)
+	document.querySelector('#meta-desc').setAttribute('content',  `View your collection of saved Geometry Dash levels!`)
 }
 
 if (gauntlet) {
-	$('body').addClass('darkBG')
-	$('.cornerPiece').addClass('grayscale')
-	$('#header').text((gauntlets[parseInt(gauntlet) - 1] || "Unknown") + " Gauntlet")
-	$('#meta-title').attr('content', (gauntlets[parseInt(gauntlet) - 1] || "Unknown") + " Gauntlet")
-	$('#meta-desc').attr('content',  `View the 5 levels in the ${(gauntlets[parseInt(gauntlet) - 1] || "Unknown") + " Gauntlet"}!`)
+	document.querySelector('body').classList.add('darkBG')
+	document.querySelector('.cornerPiece').classList.add('grayscale')
+	document.querySelector('#header').textContent = (gauntlets[parseInt(gauntlet) - 1] || "Unknown") + " Gauntlet"
+	document.querySelector('#meta-title').setAttribute('content', (gauntlets[parseInt(gauntlet) - 1] || "Unknown") + " Gauntlet")
+	document.querySelector('#meta-desc').setAttribute('content', `View the 5 levels in the ${(gauntlets[parseInt(gauntlet) - 1] || "Unknown") + " Gauntlet"}!`)
 }
 
-if (!$('#header').text() && typeof userMode != "string") $('#header').text(path == "*" ? "Online Levels" : decodeURIComponent(path))
+if (!document.querySelector('#header').textContent && typeof userMode != "string") document.querySelector('#header').textContent = path == "*" ? "Online Levels" : decodeURIComponent(path)
 
-$('.closeWindow').click(function() {$(".popup").attr('style', 'display: none;')})
+for (let el of document.querySelectorAll('.closeWindow')) el.onclick = function() {$(".popup").attr('style', 'display: none;')}
 
-$('#purgeSaved').click(function() {
+document.querySelector('#purgeSaved').onclick = function() {
 	document.cookie = "saved=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;"
 	location.reload()
-})
+};
 
 var max = 9999
 var min = 1
 
-$('#pageSelect').on('input', function () {
-    var x = $(this).val();
-    if ($(this).val() != "") $(this).val(Math.max(Math.min(Math.floor(x), max), min));
+document.querySelector('#pageSelect').addEventListener('input', function () {
+    var x = this.value;
+    if (this.value != "") this.value = Math.max(Math.min(Math.floor(x), max), min);
+}, {passive: true});
+
+document.querySelector('#pageSelect').addEventListener('blur', function () {
+    var x = this.value
+    if (this.value != "") this.value = Math.max(Math.min(Math.floor(x), max), min);
 });
 
-$('#pageSelect').on('blur', function () {
-    var x = $(this).val();
-    if ($(this).val() != "") $(this).val(Math.max(Math.min(Math.floor(x), max), min));
-});
-
-$(document).keydown(function(k) {
+document.addEventListener('keydown', function(k) {
 	if (loading) return;
 
-	if ($('#pageDiv').is(':visible')) {
-		if (k.which == 13) $('#pageJump').trigger('click') //enter 
+	if (document.querySelector('#pageDiv').style.display != 'hidden') {
+		if (k.code == "Enter") document.querySelector('#pageJump').click() //enter 
 		else return;
 	}
 
-    if (k.which == 37 && $('#pageDown').is(":visible")) { //left
-		$('#pageDown').trigger('click')
+    if (k.code == "ArrowLeft" && document.querySelector('#pageDown').style.display != 'hidden') { //left
+      document.querySelector('#pageDown').click()
 	}
 	
-	if (k.which == 39 && $('#pageUp').is(":visible")) { //right
-		$('#pageUp').trigger('click')
+	if (k.code == "ArrowRight" && document.querySelector('#pageUp').style.display != 'hidden') { //right
+		document.querySelector('#pageUp').click()
     }
-});
+}, {passive: true});
 
 </script>

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ let api = true;
 let gdicons = fs.readdirSync('./icons/iconkit')
 const compression = require('compression');
 const app = express();
+const mapPacks = require('./misc/mapPacks.json');
+const credits = require('./misc/credits.json');
 app.use(compression());
 app.use(express.json());
 app.use(express.urlencoded({extended: true}));
@@ -29,47 +31,50 @@ app.gjp = secrets.gjp
 function haltOnTimedout (req, res, next) {
   if (!req.timedout) next()
 }
-
+function pTo(...paths) {
+  return path.join(__dirname, ...paths)
+}
 app.parseResponse = function (responseBody, splitter) {
-  if (!responseBody) return {};
+  if (!responseBody || responseBody == "-1") return {};
   let response = responseBody.split('#')[0].split(splitter || ':');
   let res = {};
   for (let i = 0; i < response.length; i += 2) {
   res[response[i]] = response[i + 1]}
-  return res  }
+  return res
+}
 
 //xss bad
 app.clean = function(text) {if (typeof text != "string") return text; else return text.replace(/&/g, "&#38;").replace(/</g, "&#60;").replace(/>/g, "&#62;").replace(/=/g, "&#61;").replace(/"/g, "&#34;").replace(/'/g, "&#39;")}
 
 console.log("Site online!")
 
-app.use('/assets', express.static(__dirname + '/assets', {maxAge: "7d"}));
-app.use('/css', express.static(__dirname + '/assets/css'));
-app.use('/objects', express.static(__dirname + '/assets/objects', {maxAge: "7d"}));
-app.use('/blocks', express.static(__dirname + '/assets/blocks', {maxAge: "7d"}));
-app.use('/gauntlets', express.static(__dirname + '/assets/gauntlets', {maxAge: "7d"}));
-app.use('/difficulty', express.static(__dirname + '/assets/gdfaces', {maxAge: "7d"}));
-app.use('/iconkitbuttons', express.static(__dirname + '/assets/iconkitbuttons', {maxAge: "7d"}));
-app.use('/gdicon', express.static(__dirname + '/icons/iconkit', {maxAge: "7d"}));
+app.use('/assets', express.static(pTo('assets'), {maxAge: "7d"}));
+app.use('/css', express.static(pTo('assets', 'css')));
+app.use('/objects', express.static(pTo('assets', 'objects'), {maxAge: "7d"}));
+app.use('/blocks', express.static(pTo('assets', 'blocks'), {maxAge: "7d"}));
+app.use('/gauntlets', express.static(pTo('assets', 'gauntlets'), {maxAge: "7d"}));
+app.use('/difficulty', express.static(pTo('assets', 'gdfaces'), {maxAge: "7d"}));
+app.use('/iconkitbuttons', express.static(pTo('assets', 'iconkitbuttons'), {maxAge: "7d"}));
+app.use('/gdicon', express.static(pTo('icons', 'iconkit'), {maxAge: "7d"}));
 
 app.get("/api", function(req, res) {
-  res.sendFile(__dirname + "/html/api.html")
+  res.sendFile(pTo("html", "api.html"))
 })   
 
 app.get("/gauntlets", function(req, res) {
-  res.sendFile(__dirname + "/html/gauntlets.html")
+  res.sendFile(pTo("html", "gauntlets.html"))
 })   
 
 app.get("/mappacks", function(req, res) {
-  res.sendFile(__dirname + "/html/mappacks.html")
+  res.sendFile(pTo("html", "mappacks.html"))
 })   
 
 app.get("/search", function(req, res) {
-  res.sendFile(__dirname + "/html/filters.html")
+  res.sendFile(pTo("html", "filters.html"))
 })   
 
 app.get("/leaderboard", function(req, res) {
-  res.sendFile(__dirname + "/html/leaderboard.html")
+  res.sendFile(pTo("html", "leaderboard.html"))
 }) 
 
 app.get("/profile/:id", function(req, res) {
@@ -77,15 +82,15 @@ app.get("/profile/:id", function(req, res) {
 })  
 
 app.get("/comments/:id", function(req, res) {
-  res.sendFile(__dirname + "/html/comments.html")
+  res.sendFile(pTo("html", "comments.html"))
 })  
 
 app.get("/search/:text", function(req, res) {
-  res.sendFile(__dirname + "/html/search.html")
+  res.sendFile(pTo("html", "search.html"))
 }) 
 
 app.get("/analyze/:id", async function(req, res) {
-  res.sendFile(__dirname + "/html/analyze.html")
+  res.sendFile(pTo("html", "analyze.html"))
 })    
 
 app.get("/icon/:text", function(req, res) {
@@ -126,19 +131,19 @@ app.get("/api/leaderboard", function(req, res, api) {
 })   
 
 app.get("/api/mappacks", async function(req, res) {
-  res.send(require('./misc/mapPacks.json'))
+  res.send(mapPacks)
 })
 
 app.get("/api/credits", function(req, res) {
-  res.send(require('./misc/credits.json'))
+  res.send(credits)
 })    
 
 app.get("/iconkit", function(req, res) {
-  res.sendFile(__dirname + "/html/iconkit.html")
+  res.sendFile(pTo("html", "iconkit.html"))
 })
 
 app.get("/icon", function(req, res) {
-  res.sendFile(__dirname + "/html/iconkit.html")
+  res.sendFile(pTo("html", "iconkit.html"))
 })
 
 app.get('/api/icons', function(req, res) {
@@ -154,7 +159,7 @@ app.get("/:id", function(req, res) {
 })    
 
 app.get("/", function(req, res) {
-  res.sendFile(__dirname + "/html/home.html")
+  res.sendFile(pTo("html", "home.html"))
 })    
 
 app.get('*', function(req, res) {


### PR DESCRIPTION
jQuery is GONE!

I'm hoping that you'll merge this because it saves a bunch on page load and makes future-proofing possible. jQuery should not be used when alternatives exist for everything we need to do with jQuery.

Page load will (again) be faster without jQuery, but more importantly the project won't be using outdated techniques.

On the side: I fixed a bunch of bugs:
1. Replaced all HTML5-illegal `<font>` tags with `<span>`
2. Made iconkit work on cube (before, it selected the element after the one you chose)
3. Fixed dumb way of parsing response in `icon.js`

I understand if you don't want to merge because you don't want to try vanilla JS features, but please do consider it because most jQuery features can be replaced easily. `document.querySelector` is `$()`, and most other things are simply semantic changes. (This did take me around 4 hours because I'm bad at jQuery, but it's a learning exercise for myself even if this PR ends up being rejected.)

Thanks for reading again!