### PR TITLE
Change portal order percentage formula

### DIFF
--- a/api/analyze.js
+++ b/api/analyze.js
@@ -87,7 +87,7 @@ response.objects = data.length - 2
 response.highDetail = highDetail
 response.settings = {}
 
-response.portals = data.filter(x => x.portal).sort(function (a, b) {return parseInt(a.x) - parseInt(b.x)}).map(x => x.portal + " " + Math.round(x.x / last * 99) + "%").join(", ")
+response.portals = data.filter(x => x.portal).sort(function (a, b) {return parseInt(a.x) - parseInt(b.x)}).map(x => x.portal + " " + Math.floor(x.x / (Math.max(last, 529.0) + 340.0) * 100) + "%").join(", ")
 
 response.orbs = {}
 orbArray = data.filter(x => x.orb).reduce( (a,b) => { //stolen from https://stackoverflow.com/questions/45064107/how-do-i-group-duplicate-objects-in-an-array


### PR DESCRIPTION
The distance between the center of last block and where player starts flying to the end portal is 40.
The distance between the end portal and where player starts flying to the end portal is 300.

If you create an empty level, player will start flying to the end portal at ~569, so if last block X position is smaller than 529, the length of the level is fixed.

(Sorry for my bad english... the picture maybe easier to understand)
![1](https://user-images.githubusercontent.com/7558201/74601376-ab944380-50d8-11ea-8b2e-683d1ae739ea.png)

This is the code I found in Android version of the game, but I didn't find more accurate value for 40 and 529.
![2](https://user-images.githubusercontent.com/7558201/74601407-0c238080-50d9-11ea-9676-083aaba0a3a4.png)