### PR TITLE
Update jimp, show level data's real space in kilo/megabytes

### DIFF
--- a/api/analyze.js
+++ b/api/analyze.js
@@ -8,7 +8,7 @@ const blocks = require('../misc/blocks.json')
 module.exports = async (app, req, res, level) => {
 
 let unencrypted = level.data.startsWith('kS') // some gdps'es don't encrypt level data
-let levelString = unencrypted ? level.data : Buffer.from(level.data, 'base64') 
+let levelString = unencrypted ? level.data : Buffer.from(level.data, 'base64')
 let response = {};
 let rawData;
 
@@ -19,7 +19,7 @@ else {
     try { buffer = pako.inflate(levelString, {to:"string"}) }
     catch(e) { return res.send("-1") }
     rawData = buffer.toString('utf8')
-} 
+}
 
 let data = rawData; // data is tweaked around a lot, so rawData is preserved
 
@@ -55,7 +55,7 @@ data.forEach((x, y) => {
     if (ids.triggers[id]) obj.trigger = ids.triggers[id]
 
     if (obj.triggerGroups) obj.triggerGroups.split('.').forEach(x => triggerGroups.push(x))
-    if (obj.highDetail == 1) highDetail += 1 
+    if (obj.highDetail == 1) highDetail += 1
 
     blockNames.forEach(b => {
         if (blocks[b].includes(id)) {
@@ -230,6 +230,8 @@ Object.keys(response.settings).filter(k => {
 delete response.settings['colors']
 response.text = data.filter(x => x.message).sort(function (a, b) {return parseInt(a.x) - parseInt(b.x)}).map(x => [Buffer.from(x.message, 'base64').toString(), Math.round(x.x / last * 99) + "%"])
 response.dataLength = rawData.length
+response.dataLengthKB = response.dataLength / 1024
+response.dataLengthMB = response.dataLengthKB / 1024
 response.data = rawData
 
 return res.send(response)

--- a/assets/css/browser.css
+++ b/assets/css/browser.css
@@ -46,9 +46,9 @@ img, .noSelect {
 }
 
 .supercenter {
-    position: absolute; 
-    top: 50%; 
-    left: 50%; 
+    position: absolute;
+    top: 50%;
+    left: 50%;
     transform: translate(-50%,-50%);
 }
 
@@ -214,7 +214,7 @@ textarea::-webkit-scrollbar {
     width: 2.2%;
     background: #6d3c24;
 }
-  
+
 textarea::-webkit-scrollbar-thumb {
     background: rgb(83, 47, 28);
     overflow: hidden;
@@ -491,8 +491,8 @@ input::-webkit-inner-spin-button {
 }
 
 .popup {
-    position: fixed; 
-    display: none; 
+    position: fixed;
+    display: none;
     width: 100%;
     height: 100%;
     top: 0; left: 0; right: 0; bottom: 0;
@@ -547,9 +547,9 @@ input::-webkit-inner-spin-button {
 }
 
 #scoreTabs {
-   position: absolute; 
+   position: absolute;
    text-align: center;
-   top: 2.45%; 
+   top: 2.45%;
    width: 100%;
    margin-left: -13.5vh
 }
@@ -557,13 +557,13 @@ input::-webkit-inner-spin-button {
 #searchBox {
     background-color: rgb(173, 115, 76);
     width: 122vh;
-    height: 75%; 
-    overflow-y: auto; 
+    height: 75%;
+    overflow-y: auto;
     overflow-x: hidden;
 }
 
-#searchBox::-webkit-scrollbar, #statusDiv::-webkit-scrollbar, #commentBox::-webkit-scrollbar { 
-    display: none; 
+#searchBox::-webkit-scrollbar, #statusDiv::-webkit-scrollbar, #commentBox::-webkit-scrollbar {
+    display: none;
 }
 
 .searchResult {
@@ -708,7 +708,7 @@ input::-webkit-inner-spin-button {
     background-color: #BE6F3F;
     overflow-y: scroll;
     scrollbar-width: none;
-    -ms-overflow-style: none; 
+    -ms-overflow-style: none;
 }
 
 #msgList::-webkit-scrollbar {
@@ -838,9 +838,9 @@ input::-webkit-inner-spin-button {
     width: 1%;
     background: rgba(0, 0, 0, 0.1);
 }
-  
+
 .analysis::-webkit-scrollbar-thumb, .levelCode::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.3); 
+    background: rgba(0, 0, 0, 0.3);
     overflow: hidden;
 }
 
@@ -980,6 +980,16 @@ input::-webkit-inner-spin-button {
     margin-top: -0.3%;
 }
 
+#codeLengthKB {
+    font-size: 2.2vh;
+    margin-top: -0.3%;
+}
+
+#codeLengthMB {
+    font-size: 2.2vh;
+    margin-top: -0.3%;
+}
+
 .portalImage {
     height: 65%;
     vertical-align: top;
@@ -1078,10 +1088,10 @@ input::-webkit-inner-spin-button {
 @-moz-keyframes spin { 100% { -moz-transform: rotate(360deg); } }
 @-webkit-keyframes spin { 100% { -webkit-transform: rotate(360deg); } }
 
-@keyframes spin { 
-    100% { 
-        -webkit-transform: rotate(360deg); 
-        transform:rotate(360deg); } 
+@keyframes spin {
+    100% {
+        -webkit-transform: rotate(360deg);
+        transform:rotate(360deg); }
     }
 
 @keyframes boxAnimator {

--- a/html/analyze.html
+++ b/html/analyze.html
@@ -26,6 +26,7 @@
 
 	<div id="analysisDiv" style="margin-top: 2%; display:none">
 		<h2 id="levelName"></h2>
+		<p></p>
 		<h3 id="objectCount"></h3>
 
 		<div id="highDetailDiv">
@@ -52,7 +53,7 @@
 
 		<h1 class="topMargin2" id="orbText">Jump Rings</h1>
 		<div class="transparentBox analysis" id="orbs"></div>
-		
+
 		<h1 class="topMargin2">Block Types</h1>
 		<div class="transparentBox analysis" id="blocks"></div>
 
@@ -72,6 +73,8 @@
 		<div class="transparentBox levelCode" id="levelCode">
 			<p class="menuLink" id="revealCode">Reveal level data</p>
 			<p id="codeLength"></p>
+			<p id="codeLengthKB"></p>
+			<p id="codeLengthMB"></p>
 		</div>
 
 		<div style="height: 7%"></div>
@@ -149,7 +152,7 @@ appendPortals()
 		if (x == "total") $('#triggerText').text(`Triggers (${res.triggers[x]})`)
 		else $('#triggers').append(`<div class="inline triggerDiv"><img height="50%" src='../objects/trigger-${x}.png'><h3 style="padding-top: 7%">x${res.triggers[x]}</h3></div>`)
 	})
-	
+
 	orbList.forEach(x => {
 		if (x == "total") $('#orbText').text(`Jump Rings (${res.orbs[x]})`)
 		else $('#orbs').append(`<div class="inline orbDiv"><img height="50%" src='../objects/orb-${x}.png'><h3 style="padding-top: 7%">x${res.orbs[x]}</h3></div>`)
@@ -188,7 +191,7 @@ appendPortals()
 		let c = res.colors[x]
 
 		$('#colorDiv').append(`${y % 8 == 0 ? "<brr>" : ""}<div class="inline aColor"><div class="color" channel="${c.channel}" style="background-color: rgba(${c.cr || c.r}, ${c.cg || c.g}, ${c.cb || c.b}, ${c.opacity}); border: 0.4vh solid rgb(${c.r}, ${c.g}, ${c.b})">
-		${c.copiedChannel ? `<h3 class='copiedColor'>C:${c.copiedChannel}</h3>` : c.pColor ? `<h3 class='copiedColor'>P${c.pColor}</h3>` : c.blending ? "<h3 class='blendingDot'>•</h3>" : ""}	
+		${c.copiedChannel ? `<h3 class='copiedColor'>C:${c.copiedChannel}</h3>` : c.pColor ? `<h3 class='copiedColor'>P${c.pColor}</h3>` : c.blending ? "<h3 class='blendingDot'>•</h3>" : ""}
 		${c.copiedChannel && c.copiedHSV ? `<h3 class='copiedColor copiedHSV'> +HSV</h3>` : ""}
 		${c.opacity != "1" ? `<h3 class='copiedColor'>${c.opacity}%</h3>` : ""}
 		</div><h3 style="padding-top: 7%">${c.channel > 0 ? "Col " + c.channel : c.channel}</h3></div>`)
@@ -199,7 +202,7 @@ appendPortals()
 	$(".portalToggle").click(function() {
 		if ($(this).prop('checked')) disabledPortals = disabledPortals.filter(x => x != $(this).attr('portal'))
 		else disabledPortals.push($(this).attr('portal'))
-		
+
 		portals = res.portals.split(", ").map(x => x.split(" "))
 		if (disabledPortals.includes('form')) portals = portals.filter(x => !formPortals.includes(x[0]))
 		if (disabledPortals.includes('speed')) portals = portals.filter(x => !speedPortals.includes(x[0]))
@@ -215,7 +218,9 @@ appendPortals()
 		appendPortals()
 	})
 
-	$('#codeLength').html(`(${res.dataLength} characters)`)
+	$('#codeLength').html(`(${res.dataLength} characters/bits)`)
+	$('#codeLengthKB').html(`(${res.dataLengthKB} kilobytes)`)
+	$('#codeLengthMB').html(`(${res.dataLengthMB} megabytes)`)
 
 	$('#revealCode').click(function() {
 		$('#levelCode').html('<p>Loading...</p>')

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "compression": "^1.7.4",
     "connect-timeout": "^1.9.0",
     "express": "^4.17.1",
-    "jimp": "^0.8.4",
+    "fs": "0.0.1-security",
+    "jimp": "^0.8.5",
+    "pako": "^1.0.11",
     "plist": "^3.0.1",
     "request": "^2.88.0"
   }


### PR DESCRIPTION
1) Updated Jimp from version 0.8.4 to 0.8.5.

2) When downloading the data of a level, they might want to know how much space is being used. But they can't decrypt "800000 objects" into true values.

Doing research, every object is actually 1 byte (except I think the first one might be 2 but whatever). To get the Kilobytes, divide the level characters by 1024. To get megabytes, same thing but divide the kilobytes.

Thanks to atom, whenever I'm proofreading things and clicking it will do stupid stuff like add things that are the same thing-thats why there's a bunch of extra changes that literally don't put in anything new. The real changes are in the files:

package.json
html/analyze.html: Lines 72 - 78 and 220 - 224
api/analyze.js: Lines 230 - 235
Edit: assets/css/browser.css Lines 978 - 992

Was a blast to learn how all things work. Sorry if my code is relatively inexperienced. I guess next time I'll be forced to use Brackets.

Should be a nice feature for people viewing levels on cellular data and don't know what the special secret level data is and can't decide whether to see or not (and then see that's its garbage).