### PR TITLE
Makes images not draggable in all major browsers

### DIFF
--- a/assets/css/browser.css
+++ b/assets/css/browser.css
@@ -430,10 +430,15 @@ input::-webkit-inner-spin-button {
 .gdButton {
     cursor: pointer;
     z-index: 1;
-    user-select: none;
     pointer-events: all;
     transition-duration: 0.07s;
     transition-timing-function: ease-in-out;
+    user-drag: none; 
+    user-select: none;
+    -moz-user-select: none;
+    -webkit-user-drag: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
 }
 
 .gdButton:active {

--- a/assets/css/browser.css
+++ b/assets/css/browser.css
@@ -1092,6 +1092,7 @@ input::-webkit-inner-spin-button {
         -webkit-transform: rotate(360deg); 
         transform:rotate(360deg); } 
     }
+}
 
 @keyframes boxAnimator {
     0% {


### PR DESCRIPTION
This changes it so that in all major browsers, the buttons cannot be dragged. 