### PR TITLE
Changed img/noselect syntax to work in all major browsers

### DIFF
--- a/assets/css/browser.css
+++ b/assets/css/browser.css
@@ -21,7 +21,12 @@ body {
 }
 
 img, .noSelect {
+    user-drag: none; 
     user-select: none;
+    -moz-user-select: none;
+    -webkit-user-drag: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
 }
 
 .noClick {

--- a/assets/css/browser.css
+++ b/assets/css/browser.css
@@ -1092,7 +1092,7 @@ input::-webkit-inner-spin-button {
         -webkit-transform: rotate(360deg); 
         transform:rotate(360deg); } 
     }
-
+}
 @keyframes boxAnimator {
     0% {
         transform: scale(0) translate(-50%, -50%);


### PR DESCRIPTION
This will make the `img, .noselect` class non-draggable in every major browser. Previously buttons could be dragged whilst pressing them, cancelling the actions in many browsers (Tested on Chrome)

(Sorry for the edits, I just forgot how to word for a second)