### PR TITLE
Add port setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,4 +195,4 @@ app.use(function (err, req, res, next) {
   if (err && err.message == "Response timeout") res.status(500).send('Internal server error! (Timed out)')
 })
 
-app.listen(2000, () => console.log("Site online!"))
+app.listen(app.config.port, () => console.log(`Site online on port ${app.config.port}`))

--- a/settings.js
+++ b/settings.js
@@ -2,6 +2,8 @@
 // This isn't a JSON because you can't leave comments on them, ew
 
 module.exports = {
+    
+    port: 2000, // Port to host website on
 
     endpoint: "http://boomlings.com/database/", // Server endpoint to send requests to
 


### PR DESCRIPTION
Sometimes when hosting locally, or using something like a reverse proxy it's helpful to be able to quickly change the port of the webserver in a configuration file, so I added this option to the settings.js file.