### PR TITLE
Fix Old Cvolton's GDPS Difficulty Parsing Bug

### DIFF
--- a/api/search.js
+++ b/api/search.js
@@ -36,7 +36,7 @@ module.exports = async (app, req, res) => {
         demonFilter: req.query.demonFilter,
         page: req.query.page || 0,
         gauntlet: req.query.gauntlet || 0,
-        len: req.query.length,
+        len: req.query.length || "-",
         song: req.query.songID,
         followed: req.query.creators,
 


### PR DESCRIPTION
In really old versions of Cvolton's GDPS code, there is a short bug that prevents difficulty searching if the length parameter is not found.

https://github.com/Cvolton/GMDprivateServer/blob/d289c9b3ae0461e1f07a01bd1d8d14918cf35535/incl/levels/getGJLevels.php#L42

This adds the length parameter needed to make it work.