### PR TITLE
Fixed position for back button

### DIFF
--- a/html/gauntlets.html
+++ b/html/gauntlets.html
@@ -14,7 +14,7 @@
 
 <div id="everything" class="center" style="width: 100%; height: 100%;">
 
-	<div style="position:absolute; top: 2%; left: -1.95%; width: 10%; height: 25%; pointer-events: none">
+	<div style="position:fixed; top: 2%; left: -1.95%; width: 10%; height: 25%; pointer-events: none">
 		<img class="gdButton yesClick" id="backButton" src="../assets/back.png" height="30%" onclick="backButton()">
 	</div>
 

--- a/html/mappacks.html
+++ b/html/mappacks.html
@@ -24,7 +24,7 @@
 		<br>
 	</div>
 
-	<div style="position:absolute; top: 2%; left: -1.95%; width: 10%; height: 25%; pointer-events: none">
+	<div style="position:fixed; top: 2%; left: -1.95%; width: 10%; height: 25%; pointer-events: none">
 		<img class="gdButton yesClick" id="backButton" src="../assets/back.png" height="30%" onclick="backButton()">
 	</div> 
 	<br>


### PR DESCRIPTION
I was just scrolling through map packs and when i wanted to go back, i realised the button was at the top of the webpage, and i had to scroll all the way up just to go back. So this will make the button stay in the same position when scrolling!