### PR TITLE
Using account password instead of GJP + Leaderboard CSS fix

### DIFF
--- a/html/leaderboard.html
+++ b/html/leaderboard.html
@@ -173,8 +173,8 @@ function leaderboard(val) {
 		
 			<div class="center ranking">
 				${x.icon.icon == -1 && type == "accurate" ? `<img class="spaced" src="./assets/trophies/${trophies.findIndex(z => y+1 <= z) + 1}.png" height="150%" style="margin-bottom: 0%; transform:scale(1.1)">` : 
-				`<img class="spaced lazyLoad" data-src="./icon/icon?form=${x.icon.form}&icon=${x.icon.icon}&col1=${x.icon.col1}&col2=${x.icon.col2}&glow=${x.icon.glow}&size=auto" height="150%" style="margin-bottom: 0%; transform:scale(1.1)">`}
-				<h2 class="small" style="margin-top: 2%">${y+1}</h2>
+				`<img class="spaced lazyLoad" data-src="./icon/icon?form=${x.icon.form}&icon=${x.icon.icon}&col1=${x.icon.col1}&col2=${x.icon.col2}&glow=${x.icon.glow}&size=auto" height="150%" style="margin-bottom: 0%; transform:scale(1.1); margin-top: 30%;">`}
+				<h2 class="small" style="margin-top: 20%">${y+1}</h2>
 			</div>
 		</div>`)
 		})

--- a/index.js
+++ b/index.js
@@ -142,14 +142,14 @@ try {
   app.password = secrets.password
   app.gjp = app.xor.encrypt(app.password)
   app.sheetsKey = secrets.sheetsKey
-  if (app.id == "account id goes here" || app.password == "account password goes here") console.warn("Warning: No account ID and/or GJP has been provided in secretStuff.json! These are required for level leaderboards to work.")
+  if (app.id == "account id goes here" || app.password == "account password goes here") console.warn("Warning: No account ID and/or password has been provided in secretStuff.json! These are required for level leaderboards to work.")
   if (app.sheetsKey.startsWith("google sheets api key")) app.sheetsKey = undefined
 }
 
 catch(e) {
   app.id = 0
   app.gjp = 0
-  console.warn("Warning: secretStuff.json has not been created! These are required for level leaderboards to work.")
+  console.warn("Warning: secretStuff.json has not been created! This file is required for level leaderboards to work.")
 }
 
 app.parseResponse = function (responseBody, splitter) {

--- a/index.js
+++ b/index.js
@@ -134,12 +134,15 @@ directories.forEach(d => {
   fs.readdirSync('./api/' + d).forEach(x => {if (x.includes('.')) app.run[x.split('.')[0]] = require('./api/' + d + "/" + x) })
 })
 
+app.xor = new XOR() //why complicated gjp stuff just xor it
+
 try {
   const secrets = require("./misc/secretStuff.json")
   app.id = secrets.id
-  app.gjp = secrets.gjp
+  app.password = secrets.password
+  app.gjp = app.xor.encrypt(app.password)
   app.sheetsKey = secrets.sheetsKey
-  if (app.id == "account id goes here" || app.gjp == "account gjp goes here") console.warn("Warning: No account ID and/or GJP has been provided in secretStuff.json! These are required for level leaderboards to work.")
+  if (app.id == "account id goes here" || app.password == "account password goes here") console.warn("Warning: No account ID and/or GJP has been provided in secretStuff.json! These are required for level leaderboards to work.")
   if (app.sheetsKey.startsWith("google sheets api key")) app.sheetsKey = undefined
 }
 
@@ -159,8 +162,6 @@ app.parseResponse = function (responseBody, splitter) {
   res[response[i]] = response[i + 1]}
   return res  
 }
-
-app.xor = new XOR()
 
 //xss bad
 app.clean = function(text) {if (!text || typeof text != "string") return text; else return text.replace(/&/g, "&#38;").replace(/</g, "&#60;").replace(/>/g, "&#62;").replace(/=/g, "&#61;").replace(/"/g, "&#34;").replace(/'/g, "&#39;")}

--- a/misc/secretStuff.json
+++ b/misc/secretStuff.json
@@ -1,5 +1,5 @@
 {
     "id": "account id goes here",
-    "gjp": "account gjp goes here",
+    "password": "account password goes here",
     "sheetsKey": "google sheets api key (for accurate leaderboard - delete this line if you don't need it)"
 }


### PR DESCRIPTION
So far, there's almost no documentation about how to obtain the GJP, so I modded this around a bit to instead use the normal account password and then convert it to GJP. (I almost messed up my "magical little fork" when I realized it's basically xor-encrypted and base64-encoded using the default key)

Also, the leaderboard is kind of visually broken, but it can be fixed using normal CSS. (at least on Firefox)