### PR TITLE
Fixed dropdown menu on "Level Analysis"

### DIFF
--- a/html/api.html
+++ b/html/api.html
@@ -739,18 +739,18 @@
 			<br>If the song was published after March 2017, the artist must also be whitelisted by a GD moderator.</p>
 
 			<br>
-			<p class="reveal" onclick="$('#params-analyze').slideToggle(100)"><b>Parameters (0)</b></p>
-			<div class="subdiv" id="params-analyze">
+			<p class="reveal" onclick="$('#params-artist').slideToggle(100)"><b>Parameters (0)</b></p>
+			<div class="subdiv" id="params-artist">
 				<p>No parameters for this one!</p>
 			</div>
 
 			<br>
-			<p class="reveal" onclick="$('#response-analyze').slideToggle(100)"><b>Response (1)</b></p>
-			<div class="subdiv" id="response-analyze">
+			<p class="reveal" onclick="$('#response-artist').slideToggle(100)"><b>Response (1)</b></p>
+			<div class="subdiv" id="response-artist">
 				<p>literally just returns true or false (or -1 if there's an error)</p>
 				<p>there used to be more but rob disabled his song api sooo</p>
 			</div>
-			<!-- <p class="reveal" onclick="$('#response-analyze').slideToggle(100)"><b>Response (8)</b></p>
+			<!-- <p class="reveal" onclick="$('#response-artist').slideToggle(100)"><b>Response (8)</b></p>
 			<div class="subdiv" id="response-analyze">
 				<p>error: Appears if the GD servers rejected the request or not. <code>song.allowed</code> may still work even with an error</p>
 				<p>exists: If the provided song exists on Newgrounds</p>


### PR DESCRIPTION
Clicking on "Level Analysis" on the API documentation would cause "Song Verification" to open instead of the intended one.