### PR TITLE
fix for canvas so no one encounters an error like me

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "ag-psd": "^14.3.2",
-    "canvas": "^2.8.0",
+    "canvas": "2.8.0",
     "compression": "^1.7.4",
     "connect-timeout": "^1.9.0",
     "express": "^4.17.1",


### PR DESCRIPTION
idk if its just me who had this issue, but this assuming it fixed for me no one should encounter an error with canvas version changed.
Literally all this does is change line 12 from "^2.8.0" to "2.8.0" again dont know if everyone will have this error but ye you would know if you accept the changes