### PR TITLE
Refactored XOR.js to call `replace` once

### DIFF
--- a/classes/XOR.js
+++ b/classes/XOR.js
@@ -1,5 +1,5 @@
 module.exports = class XOR {
     xor(str, key) { return String.fromCodePoint(...str.split('').map((char, i) => char.charCodeAt(0) ^ key.toString().charCodeAt(i % key.toString().length))) }
-    encrypt(str, key = 37526) { return Buffer.from(this.xor(str, key)).toString('base64').replace(/./gs, c => {'/': '_', '+': '-'}[c] || c); }
-    decrypt(str, key = 37526) { return this.xor(Buffer.from(str.replace(/./gs, c => {'/': '_', '+': '-'}[c] || c), 'base64').toString(), key) }
+    encrypt(str, key = 37526) { return Buffer.from(this.xor(str, key)).toString('base64').replace(/./gs, c => ({'/': '_', '+': '-'}[c] || c)); }
+    decrypt(str, key = 37526) { return this.xor(Buffer.from(str.replace(/./gs, c => ({'/': '_', '+': '-'}[c] || c)), 'base64').toString(), key) }
 }

--- a/classes/XOR.js
+++ b/classes/XOR.js
@@ -1,5 +1,5 @@
 module.exports = class XOR {
     xor(str, key) { return String.fromCodePoint(...str.split('').map((char, i) => char.charCodeAt(0) ^ key.toString().charCodeAt(i % key.toString().length))) }
-    encrypt(str, key = 37526) { return Buffer.from(this.xor(str, key)).toString('base64').replace(/\//g, '_').replace(/\+/g, '-'); }
-    decrypt(str, key = 37526) { return this.xor(Buffer.from(str.replace(/\//g, '_').replace(/\+/g, '-'), 'base64').toString(), key) }
+    encrypt(str, key = 37526) { return Buffer.from(this.xor(str, key)).toString('base64').replace(/./gs, c => {'/': '_', '+': '-'}[c] || c); }
+    decrypt(str, key = 37526) { return this.xor(Buffer.from(str.replace(/./gs, c => {'/': '_', '+': '-'}[c] || c), 'base64').toString(), key) }
 }


### PR DESCRIPTION
Now it's optimized and refactored to replace the same chars as before and leave other chars intact. The `s` (dot-all) flag is used to reduce conditional branching. I don't know if this code is actually better in the Node env, I just wanted to suggest this as a possible alternative