### PR TITLE
Fix for the green color of unregistered users not being visible

### DIFF
--- a/assets/css/browser.css
+++ b/assets/css/browser.css
@@ -558,6 +558,10 @@ input::-webkit-outer-spin-button, input::-webkit-inner-spin-button {
     border-bottom: 2px solid lime
 }
 
+.unregistered {
+    -webkit-text-fill-color: unset;
+}
+
 .unregistered:hover {
     color: rgb(0, 230, 0);
 }


### PR DESCRIPTION
Due to the gradient and the property of `-webkit-text-fill-color` set to `transparent`, unregistered users look just like normal, registered users. This uses the `unregistered` class on h2 to fix this.
(just a small little fix for something that kind of annoys me)