### PR TITLE
Show repo size in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ welp, here's the readme. but you've been warned,,,
 
 
 # GDBrowser
-
+![Repo size](https://img.shields.io/github/repo-size/GDColon/GDBrowser)
   
 
 Uh... so I've never actually used GitHub before this. But I'll try to explain everything going on here.


### PR DESCRIPTION
Currently, GH doesn't show this info in the UI, so this "badge" is useful for everyone who clones/downloads the repository. It better informs users about the estimated download time, and how much space they need in an arbitrary drive (not just HDD or SSD)